### PR TITLE
Fix support for Doctrine 2.9 & 3.1

### DIFF
--- a/src/Adapter/ConnectionSqlFixture.php
+++ b/src/Adapter/ConnectionSqlFixture.php
@@ -5,9 +5,12 @@ namespace Kununu\DataFixtures\Adapter;
 
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Exception\InvalidFileException;
+use Kununu\DataFixtures\Tools\ConnectionToolsTrait;
 
 abstract class ConnectionSqlFixture implements ConnectionFixtureInterface
 {
+    use ConnectionToolsTrait;
+
     final public function load(Connection $connection): void
     {
         foreach ($this->fileNames() as $fileName) {
@@ -18,7 +21,7 @@ abstract class ConnectionSqlFixture implements ConnectionFixtureInterface
             }
 
             if ($sql = $this->getSql($file)) {
-                $connection->executeStatement($sql);
+                $this->executeQuery($connection, $sql);
             }
         }
     }

--- a/src/Executor/ConnectionExecutor.php
+++ b/src/Executor/ConnectionExecutor.php
@@ -31,7 +31,7 @@ final class ConnectionExecutor implements ExecutorInterface
                 $this->purger->purge();
             }
 
-            $this->connection->executeStatement($this->getDisableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
+            $this->executeQuery($this->connection, $this->getDisableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
 
             foreach ($fixtures as $fixture) {
                 $this->load($fixture);
@@ -42,7 +42,7 @@ final class ConnectionExecutor implements ExecutorInterface
             $this->connection->rollBack();
             throw $e;
         } finally {
-            $this->connection->executeStatement($this->getEnableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
+            $this->executeQuery($this->connection, $this->getEnableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
         }
     }
 

--- a/src/Purger/ConnectionPurger.php
+++ b/src/Purger/ConnectionPurger.php
@@ -43,7 +43,7 @@ final class ConnectionPurger implements PurgerInterface
         $this->connection->beginTransaction();
 
         try {
-            $this->connection->executeStatement($this->getDisableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
+            $this->executeQuery($this->connection, $this->getDisableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
 
             foreach ($tables as $tableName) {
                 $this->purgeTable($platform, $tableName);
@@ -54,7 +54,7 @@ final class ConnectionPurger implements PurgerInterface
             $this->connection->rollBack();
             throw $e;
         } finally {
-            $this->connection->executeStatement($this->getEnableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
+            $this->executeQuery($this->connection, $this->getEnableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
         }
     }
 
@@ -75,9 +75,9 @@ final class ConnectionPurger implements PurgerInterface
     private function purgeTable(AbstractPlatform $platform, string $tableName): void
     {
         if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-            $this->connection->executeStatement('DELETE FROM ' . $this->connection->quoteIdentifier($tableName));
+            $this->executeQuery($this->connection, 'DELETE FROM ' . $this->connection->quoteIdentifier($tableName));
         } else {
-            $this->connection->executeStatement($platform->getTruncateTableSQL($this->connection->quoteIdentifier($tableName), true));
+            $this->executeQuery($this->connection, $platform->getTruncateTableSQL($this->connection->quoteIdentifier($tableName), true));
         }
     }
 }

--- a/src/Tools/ConnectionToolsTrait.php
+++ b/src/Tools/ConnectionToolsTrait.php
@@ -18,6 +18,16 @@ trait ConnectionToolsTrait
         return $connection->getSchemaManager()->listTableNames();
     }
 
+    protected function executeQuery(Connection $connection, string $sql): int
+    {
+        // This way we support both doctrine/dbal ^2.9 and ^3.1
+        if (method_exists($connection, 'executeStatement')) {
+            return $connection->executeStatement($sql);
+        }
+
+        return $connection->exec($sql);
+    }
+
     protected function getDisableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
         if ($driver instanceof Driver\AbstractMySQLDriver) {

--- a/tests/Adapter/ConnectionSqlFixtureTest.php
+++ b/tests/Adapter/ConnectionSqlFixtureTest.php
@@ -6,11 +6,14 @@ namespace Kununu\DataFixtures\Tests\Adapter;
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Exception\InvalidFileException;
 use Kununu\DataFixtures\Tests\TestFixtures\ConnectionSqlFixture1;
+use Kununu\DataFixtures\Tests\Utils\ConnectionUtilsTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ConnectionSqlFixtureTest extends TestCase
 {
+    use ConnectionUtilsTrait;
+
     public function testLoad(): void
     {
         /** @var Connection|MockObject $connection */
@@ -28,11 +31,12 @@ SQL;
 
         $connection
             ->expects($this->exactly(2))
-            ->method('executeStatement')
+            ->method($this->getExecuteQueryMethodName($connection))
             ->withConsecutive(
                 [$fixture1Content],
                 [$fixture2Content]
-            );
+            )
+            ->willReturn(1);
 
         $fixture = new ConnectionSqlFixture1();
         $fixture->load($connection);

--- a/tests/Executor/ConnectionExecutorTest.php
+++ b/tests/Executor/ConnectionExecutorTest.php
@@ -8,11 +8,14 @@ use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 use Kununu\DataFixtures\Executor\ConnectionExecutor;
 use Kununu\DataFixtures\Purger\PurgerInterface;
+use Kununu\DataFixtures\Tests\Utils\ConnectionUtilsTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ConnectionExecutorTest extends TestCase
 {
+    use ConnectionUtilsTrait;
+
     /** @var Connection|MockObject */
     private $connection;
 
@@ -23,8 +26,9 @@ final class ConnectionExecutorTest extends TestCase
     {
         $this->connection
             ->expects($this->exactly(2))
-            ->method('executeStatement')
-            ->withConsecutive(['SET FOREIGN_KEY_CHECKS=0'], ['SET FOREIGN_KEY_CHECKS=1']);
+            ->method($this->getExecuteQueryMethodName($this->connection))
+            ->withConsecutive(['SET FOREIGN_KEY_CHECKS=0'], ['SET FOREIGN_KEY_CHECKS=1'])
+            ->willReturn(1);
 
         $this->connection
             ->expects($this->once())
@@ -49,8 +53,9 @@ final class ConnectionExecutorTest extends TestCase
 
         $this->connection
             ->expects($this->exactly(2))
-            ->method('executeStatement')
-            ->withConsecutive(['SET FOREIGN_KEY_CHECKS=0'], ['SET FOREIGN_KEY_CHECKS=1']);
+            ->method($this->getExecuteQueryMethodName($this->connection))
+            ->withConsecutive(['SET FOREIGN_KEY_CHECKS=0'], ['SET FOREIGN_KEY_CHECKS=1'])
+            ->willReturn(1);
 
         $this->connection
             ->expects($this->once())
@@ -76,6 +81,11 @@ final class ConnectionExecutorTest extends TestCase
 
     public function testThatDoesNotPurgesWhenAppendIsEnabled(): void
     {
+        $this->connection
+            ->expects($this->any())
+            ->method($this->getExecuteQueryMethodName($this->connection))
+            ->willReturn(1);
+
         $this->purger
             ->expects($this->never())
             ->method('purge');
@@ -87,6 +97,11 @@ final class ConnectionExecutorTest extends TestCase
 
     public function testThatPurgesWhenAppendIsDisabled(): void
     {
+        $this->connection
+            ->expects($this->any())
+            ->method($this->getExecuteQueryMethodName($this->connection))
+            ->willReturn(1);
+
         $this->purger
             ->expects($this->once())
             ->method('purge');
@@ -98,6 +113,11 @@ final class ConnectionExecutorTest extends TestCase
 
     public function testThatFixturesAreLoaded(): void
     {
+        $this->connection
+            ->expects($this->any())
+            ->method($this->getExecuteQueryMethodName($this->connection))
+            ->willReturn(1);
+
         $fixture1 = $this->createMock(ConnectionFixtureInterface::class);
         $fixture1->expects($this->once())->method('load')->with($this->connection);
 

--- a/tests/Purger/ConnectionPurgerTest.php
+++ b/tests/Purger/ConnectionPurgerTest.php
@@ -9,11 +9,14 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Kununu\DataFixtures\Exception\InvalidConnectionPurgeModeException;
 use Kununu\DataFixtures\Purger\ConnectionPurger;
+use Kununu\DataFixtures\Tests\Utils\ConnectionUtilsTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ConnectionPurgerTest extends TestCase
 {
+    use ConnectionUtilsTrait;
+
     private const TABLES = ['table_1', 'table_2', 'table_3'];
     private const EXCLUDED_TABLES = ['table_4', 'table_2', 'table_5'];
 
@@ -24,8 +27,9 @@ final class ConnectionPurgerTest extends TestCase
 
         $connection
             ->expects($this->exactly(5))
-            ->method('executeStatement')
-            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement());
+            ->method($this->getExecuteQueryMethodName($connection))
+            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement())
+            ->willReturn(1);
 
         $transactionStarted = false;
         $connection
@@ -55,8 +59,9 @@ final class ConnectionPurgerTest extends TestCase
 
         $connection
             ->expects($this->exactly(5))
-            ->method('executeStatement')
-            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement());
+            ->method($this->getExecuteQueryMethodName($connection))
+            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement())
+            ->willReturn(1);
 
         $transactionStarted = false;
         $connection
@@ -89,7 +94,7 @@ final class ConnectionPurgerTest extends TestCase
 
         $connection
             ->expects($this->never())
-            ->method('executeStatement');
+            ->method($this->getExecuteQueryMethodName($connection));
 
         $purger = new ConnectionPurger($connection);
         $purger->purge();
@@ -102,8 +107,9 @@ final class ConnectionPurgerTest extends TestCase
 
         $connection
             ->expects($this->exactly(4))
-            ->method('executeStatement')
-            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement(1, self::TABLES, self::EXCLUDED_TABLES));
+            ->method($this->getExecuteQueryMethodName($connection))
+            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement(1, self::TABLES, self::EXCLUDED_TABLES))
+            ->willReturn(1);
 
         $purger = new ConnectionPurger(
             $connection,
@@ -120,8 +126,9 @@ final class ConnectionPurgerTest extends TestCase
 
         $connection
             ->expects($this->exactly(5))
-            ->method('executeStatement')
-            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement());
+            ->method($this->getExecuteQueryMethodName($connection))
+            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement())
+            ->willReturn(1);
 
         $purger = new ConnectionPurger($connection);
 
@@ -156,8 +163,9 @@ final class ConnectionPurgerTest extends TestCase
 
         $connection
             ->expects($this->exactly(5))
-            ->method('executeStatement')
-            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement(2));
+            ->method($this->getExecuteQueryMethodName($connection))
+            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement(2))
+            ->willReturn(1);
 
         $purger = new ConnectionPurger($connection);
 

--- a/tests/Utils/ConnectionUtilsTrait.php
+++ b/tests/Utils/ConnectionUtilsTrait.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Tests\Utils;
+
+use Doctrine\DBAL\Connection;
+
+trait ConnectionUtilsTrait
+{
+    public function getExecuteQueryMethodName(Connection $connection): string
+    {
+        // This way we support both doctrine/dbal ^2.9 and ^3.1
+        if (method_exists($connection, 'executeStatement')) {
+            return 'executeStatement';
+        }
+
+        return 'exec';
+    }
+}


### PR DESCRIPTION
Change all places where we were calling executeStatement and change it to call `exec` or `executeStatement` so that we support multiple versions of doctrine. 