### PR TITLE
Non-transactional database fixtures executor/purger

### DIFF
--- a/docs/FixtureTypes/doctrine-dbal-connection-fixtures.md
+++ b/docs/FixtureTypes/doctrine-dbal-connection-fixtures.md
@@ -14,7 +14,9 @@ composer require doctrine/dbal
 
 ### 1. Create fixture classes
 
-The first step to load *Connection Fixtures* is to create fixtures classes. This classes must implement the [ConnectionFixtureInterface](/src/Adapter/ConnectionFixtureInterface.php) or extend the class [ConnectionSqlFixture](/src/Adapter/ConnectionSqlFixture.php) which allows you to define fixtures using *Sql*  files.
+The first step to load *Connection Fixtures* is to create fixtures classes.
+
+This classes must implement the [ConnectionFixtureInterface](/src/Adapter/ConnectionFixtureInterface.php) or extend the class [ConnectionSqlFixture](/src/Adapter/ConnectionSqlFixture.php) which allows you to define fixtures using *Sql* files.
 
 
 ```php
@@ -128,5 +130,6 @@ $purger->setPurgeMode(2); // PURGE_MODE_TRUNCATE
 
 ## Notes
 
-- Connection Executor and Connection Purger are transactional.
-- Connection Executor and Connection Purger disable foreign keys checks before running and enable them after they run.
+- `Kununu\DataFixtures\Executor\ConnectionExecutor` and `Kununu\DataFixtures\Purger\ConnectionPurger` are **transactional**.
+  - If you need to run **non-transactional** fixtures then use `Kununu\DataFixtures\Executor\NonTransactionalConnectionExecutor` and `Kununu\DataFixtures\Purger\NonTransactionalConnectionPurger`  
+- Both kinds of executor/purger disable foreign keys checks before running and enable them after they run.

--- a/docs/how-to-create-new-fixture-type.md
+++ b/docs/how-to-create-new-fixture-type.md
@@ -1,8 +1,11 @@
 # How to create a new Fixture Type
 
-This package already provides implementations to load fixtures for some storage types. You can find the list of all supported storage types [here](/README.md/#Fixtures-types).
+This package already provides implementations to load fixtures for some storage types.
+
+You can find the list of all supported storage types [here](/README.md#Fixtures-types).
 Still, if you have the need to create a new type you can do it and it's pretty simple.
-For example, let's imagine that you need to load fixtures(in this case files) to a specific directory. To get this new type of fixtures up and running you will need to create a set of elements:
+
+For example, let's imagine that you need to load fixtures (in this case files) to a specific directory. To get this new type of fixtures up and running you will need to create a set of elements:
 - [Fixture Interface](#Create-fixture-type-interface)
 - [Purger](#Create-Purger)
 - [Loader](#Create-Loader)
@@ -12,10 +15,14 @@ For example, let's imagine that you need to load fixtures(in this case files) to
 ## Create fixture type interface
 
 Any fixture that you create will need to implement the [FixtureInterface](/src/FixtureInterface.php) provided by this package.
-In this example we will create the *DirectoryFilesFixtureInterface*, which exposes a method called *load* that will receive the directory name on which the fixtures should be loaded. It's then up to your concrete fixtures to save the files in the directory. We will create those concrete fixtures later.
+
+In this example we will create the *DirectoryFilesFixtureInterface*, which exposes a method called *load* that will receive the directory name on which the fixtures should be loaded.
+
+It's then up to your concrete fixtures to save the files in the directory. We will create those concrete fixtures later.
 
 ```php
 <?php
+declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Adapter;
 
@@ -30,12 +37,15 @@ interface DirectoryFilesFixtureInterface extends FixtureInterface
 ## Create Purger
 
 A purger is a class responsible for clearing the contents of a data storage.
+
 In order to create a new Purger you need to implement the [PurgerInterface](/src/Purger/PurgerInterface.php).
+
 In this example, the Purger will be responsible for removing all files in a specific directory.
 
 
 ```php
 <?php
+declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Purger;
 
@@ -64,10 +74,15 @@ final class DirectoryPurger implements PurgerInterface
 
 ## Create Loader
 
-A loader is a class responsible for loading data fixtures of a specific type in multiple ways. In order to ease the creating of a loader this package already provides a default [loader](/src/Loader/Loader.php) which only requires you to define which types of fixtures it supports. In this example we will create the *DirectoryFixturesLoader* which extends the *default* loader.
+A loader is a class responsible for loading data fixtures of a specific type in multiple ways.
+
+In order to ease the creating of a loader this package already provides a default [loader](/src/Loader/Loader.php) which only requires you to define which types of fixtures it supports.
+
+In this example we will create the *DirectoryFixturesLoader* which extends the *default* loader.
 
 ```php
 <?php
+declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Loader;
 
@@ -84,12 +99,15 @@ final class DirectoryFixturesLoader extends Loader
 
 ## Create Executor
 
-A Executor is a class responsible of orchestrating the flow: calling the purger and loading the fixtures.
+An Executor is a class responsible for orchestrating the flow: calling the purger and loading the fixtures.
+
 In order to create a new Executor you need to implement the [ExecutorInterface](/src/Executor/ExecutorInterface.php).
+
 In this example, the Executor will be responsible for calling the Purger and load each fixture.
 
 ```php
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Executor;
 
@@ -107,7 +125,7 @@ final class DirectoryExecutor implements ExecutorInterface
         $this->purger = $purger;
     }
 
-    public function execute(array $fixtures, $append = false) : void
+    public function execute(array $fixtures, bool $append = false) : void
     {
         if ($append === false) {
             $this->purger->purge();
@@ -123,16 +141,17 @@ final class DirectoryExecutor implements ExecutorInterface
         $fixture->load($this->dirname);
     }
 }
-
 ```
 
 ## Create Fixtures
 
 Now that we created all the pieces required to load fixtures into a directory it's time to create the concrete fixtures.
+
 In this example we will create two fixtures classes that will save files to a directory.
 
 ```php
 <?php
+declare(strict_types=1);
 
 namespace Kununu\DataFixtures;
 
@@ -154,11 +173,11 @@ final class DirectoryFixture1 implements DirectoryFilesFixtureInterface
         file_put_contents($fileName, $file);
     }
 }
-
 ```
 
 ```php
 <?php
+declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Purger;
 
@@ -182,13 +201,13 @@ final class DirectoryFixture2 implements DirectoryFilesFixtureInterface
 }
 ```
 
-
 ## Putting it all together
 
 Now that you created your fixtures, the Purger, the Executor and the Loader it's time to put it all together:
 
 ```php
 <?php
+declare(strict_types=1);
 
 require __DIR__ . '/vendor/autoload.php';
 

--- a/src/Executor/CachePoolExecutor.php
+++ b/src/Executor/CachePoolExecutor.php
@@ -18,7 +18,7 @@ final class CachePoolExecutor implements ExecutorInterface
         $this->purger = $purger;
     }
 
-    public function execute(array $fixtures, $append = false): void
+    public function execute(array $fixtures, bool $append = false): void
     {
         if ($append === false) {
             $this->purger->purge();

--- a/src/Executor/ElasticSearchExecutor.php
+++ b/src/Executor/ElasticSearchExecutor.php
@@ -20,7 +20,7 @@ final class ElasticSearchExecutor implements ExecutorInterface
         $this->purger = $purger;
     }
 
-    public function execute(array $fixtures, $append = false): void
+    public function execute(array $fixtures, bool $append = false): void
     {
         if (false === $append) {
             $this->purger->purge();

--- a/src/Executor/ExecutorInterface.php
+++ b/src/Executor/ExecutorInterface.php
@@ -5,5 +5,5 @@ namespace Kununu\DataFixtures\Executor;
 
 interface ExecutorInterface
 {
-    public function execute(array $fixtures, $append = false): void;
+    public function execute(array $fixtures, bool $append = false): void;
 }

--- a/src/Executor/HttpClientExecutor.php
+++ b/src/Executor/HttpClientExecutor.php
@@ -18,7 +18,7 @@ final class HttpClientExecutor implements ExecutorInterface
         $this->purger = $purger;
     }
 
-    public function execute(array $fixtures, $append = false): void
+    public function execute(array $fixtures, bool $append = false): void
     {
         if ($append === false) {
             $this->purger->purge();

--- a/src/Executor/NonTransactionalConnectionExecutor.php
+++ b/src/Executor/NonTransactionalConnectionExecutor.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Executor;
+
+use Doctrine\DBAL\Connection;
+use Kununu\DataFixtures\Purger\PurgerInterface;
+
+final class NonTransactionalConnectionExecutor implements ExecutorInterface
+{
+    private $executor;
+
+    public function __construct(Connection $connection, PurgerInterface $purger)
+    {
+        $this->executor = new ConnectionExecutor($connection, $purger, false);
+    }
+
+    public function execute(array $fixtures, $append = false): void
+    {
+        $this->executor->execute($fixtures, $append);
+    }
+}

--- a/src/Purger/NonTransactionalConnectionPurger.php
+++ b/src/Purger/NonTransactionalConnectionPurger.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Purger;
+
+use Doctrine\DBAL\Connection;
+
+final class NonTransactionalConnectionPurger implements PurgerInterface
+{
+    private $purger;
+
+    public function __construct(Connection $connection, array $excludedTables = [])
+    {
+        $this->purger = new ConnectionPurger($connection, $excludedTables, false);
+    }
+
+    public function purge(): void
+    {
+        $this->purger->purge();
+    }
+}

--- a/tests/Executor/NonTransactionalConnectionExecutorTest.php
+++ b/tests/Executor/NonTransactionalConnectionExecutorTest.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Tests\Executor;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Exception;
+use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
+use Kununu\DataFixtures\Executor\NonTransactionalConnectionExecutor;
+use Kununu\DataFixtures\Purger\PurgerInterface;
+use Kununu\DataFixtures\Tests\Utils\ConnectionUtilsTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class NonTransactionalConnectionExecutorTest extends TestCase
+{
+    use ConnectionUtilsTrait;
+
+    /** @var Connection|MockObject */
+    private $connection;
+
+    /** @var PurgerInterface|MockObject */
+    private $purger;
+
+    public function testThatExecutorIsNotTransactionalAndLoadsFixture(): void
+    {
+        $this->connection
+            ->expects($this->exactly(2))
+            ->method($this->getExecuteQueryMethodName($this->connection))
+            ->withConsecutive(['SET FOREIGN_KEY_CHECKS=0'], ['SET FOREIGN_KEY_CHECKS=1'])
+            ->willReturn(1);
+
+        $this->connection
+            ->expects($this->never())
+            ->method('beginTransaction');
+
+        $this->connection
+            ->expects($this->never())
+            ->method('commit');
+
+        $this->purger
+            ->expects($this->never())
+            ->method('purge');
+
+        $fixture = $this->createMock(ConnectionFixtureInterface::class);
+        $fixture
+            ->expects($this->once())
+            ->method('load')
+            ->with($this->connection);
+
+        $executor = new NonTransactionalConnectionExecutor($this->connection, $this->purger);
+
+        $executor->execute([$fixture], true);
+    }
+
+    public function testThatExecutorIsNotTransactionalAndDoesNotRollbacks(): void
+    {
+        $this->expectException(Exception::class);
+
+        $this->connection
+            ->expects($this->exactly(2))
+            ->method($this->getExecuteQueryMethodName($this->connection))
+            ->withConsecutive(['SET FOREIGN_KEY_CHECKS=0'], ['SET FOREIGN_KEY_CHECKS=1'])
+            ->willReturn(1);
+
+        $this->connection
+            ->expects($this->never())
+            ->method('beginTransaction');
+
+        $this->connection
+            ->expects($this->never())
+            ->method('commit');
+
+        $this->connection
+            ->expects($this->never())
+            ->method('rollBack');
+
+        $this->purger
+            ->expects($this->once())
+            ->method('purge');
+
+        $fixture = $this->createMock(ConnectionFixtureInterface::class);
+        $fixture
+            ->expects($this->once())
+            ->method('load')
+            ->with($this->connection)
+            ->willThrowException(new Exception());
+
+        $executor = new NonTransactionalConnectionExecutor($this->connection, $this->purger);
+
+        $executor->execute([$fixture]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->createMock(Connection::class);
+        $this->connection
+            ->expects($this->any())
+            ->method('getDriver')
+            ->willReturn($this->createMock(AbstractMySQLDriver::class));
+        $this->purger = $this->createMock(PurgerInterface::class);
+    }
+}

--- a/tests/Purger/ConnectionPurgerTest.php
+++ b/tests/Purger/ConnectionPurgerTest.php
@@ -4,23 +4,14 @@ declare(strict_types=1);
 namespace Kununu\DataFixtures\Tests\Purger;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Exception;
 use Kununu\DataFixtures\Exception\InvalidConnectionPurgeModeException;
 use Kununu\DataFixtures\Purger\ConnectionPurger;
-use Kununu\DataFixtures\Tests\Utils\ConnectionUtilsTrait;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
-final class ConnectionPurgerTest extends TestCase
+final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 {
-    use ConnectionUtilsTrait;
-
-    private const TABLES = ['table_1', 'table_2', 'table_3'];
-    private const EXCLUDED_TABLES = ['table_4', 'table_2', 'table_5'];
-
     public function testThatPurgerIsTransactionalAndCommits(): void
     {
         /** @var MockObject|Connection $connection */
@@ -207,77 +198,5 @@ final class ConnectionPurgerTest extends TestCase
 
         $purger = new ConnectionPurger($connection);
         $purger->setPurgeMode(10);
-    }
-
-    private function getConnectionMock(bool $withPlatform = true, array $tables = self::TABLES): MockObject
-    {
-        $connection = $this->createMock(Connection::class);
-
-        $schemaManager = $this->createMock(AbstractSchemaManager::class);
-        $schemaManager->expects($this->any())->method('listTableNames')->willReturn($tables);
-
-        // To support doctrine/dbal ^2.9 and ^3.1
-        if (method_exists($connection, 'createSchemaManager')) {
-            $connection->expects($this->any())->method('createSchemaManager')->willReturn($schemaManager);
-        } else {
-            $connection->expects($this->any())->method('getSchemaManager')->willReturn($schemaManager);
-        }
-
-        $connection->expects($this->any())->method('getDriver')->willReturn($this->createMock(AbstractMySQLDriver::class));
-        $connection->expects($this->any())->method('quoteIdentifier')->willReturnArgument(0);
-
-        if ($withPlatform) {
-            $connection->expects($this->any())->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
-        }
-
-        return $connection;
-    }
-
-    private function getConsecutiveArgumentsForConnectionExecStatement(?int $purgeMode = 1, ?array $tables = self::TABLES, ?array $excludedTables = []): array
-    {
-        $purgeStatements = [];
-
-        switch ($purgeMode) {
-            case 1: // PURGE_MODE_DELETE
-                $purgeStatements = $this->getDeleteModeConnectionWithConsecutiveArguments($tables, $excludedTables);
-                break;
-            case 2: // PURGE_MODE_TRUNCATE
-                $purgeStatements = $this->getTruncateModeConnectionWithConsecutiveArguments($tables, $excludedTables);
-                break;
-            default:
-                break;
-        }
-
-        return array_merge(
-            [['SET FOREIGN_KEY_CHECKS=0']],
-            $purgeStatements,
-            [['SET FOREIGN_KEY_CHECKS=1']]
-        );
-    }
-
-    private function getDeleteModeConnectionWithConsecutiveArguments(array $tables = self::TABLES, array $excludedTables = []): array
-    {
-        $return = [];
-
-        foreach ($tables as $tableName) {
-            if (!in_array($tableName, $excludedTables)) {
-                $return[] = [sprintf('DELETE FROM %s', $tableName)];
-            }
-        }
-
-        return $return;
-    }
-
-    private function getTruncateModeConnectionWithConsecutiveArguments(array $tables = self::TABLES, array $excludedTables = []): array
-    {
-        $return = [];
-
-        foreach ($tables as $tableName) {
-            if (!in_array($tableName, $excludedTables)) {
-                $return[] = [sprintf('TRUNCATE %s', $tableName)];
-            }
-        }
-
-        return $return;
     }
 }

--- a/tests/Purger/ConnectionPurgerTestCase.php
+++ b/tests/Purger/ConnectionPurgerTestCase.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Tests\Purger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Kununu\DataFixtures\Tests\Utils\ConnectionUtilsTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class ConnectionPurgerTestCase extends TestCase
+{
+    use ConnectionUtilsTrait;
+
+    protected const TABLES = ['table_1', 'table_2', 'table_3'];
+    protected const EXCLUDED_TABLES = ['table_4', 'table_2', 'table_5'];
+
+    protected function getConnectionMock(bool $withPlatform = true, array $tables = self::TABLES): MockObject
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->expects($this->any())->method('listTableNames')->willReturn($tables);
+
+        // To support doctrine/dbal ^2.9 and ^3.1
+        if (method_exists($connection, 'createSchemaManager')) {
+            $connection->expects($this->any())->method('createSchemaManager')->willReturn($schemaManager);
+        } else {
+            $connection->expects($this->any())->method('getSchemaManager')->willReturn($schemaManager);
+        }
+
+        $connection->expects($this->any())->method('getDriver')->willReturn($this->createMock(AbstractMySQLDriver::class));
+        $connection->expects($this->any())->method('quoteIdentifier')->willReturnArgument(0);
+
+        if ($withPlatform) {
+            $connection->expects($this->any())->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+        }
+
+        return $connection;
+    }
+
+    protected function getConsecutiveArgumentsForConnectionExecStatement(
+        ?int $purgeMode = 1,
+        ?array $tables = self::TABLES,
+        ?array $excludedTables = []
+    ): array {
+        $purgeStatements = [];
+
+        switch ($purgeMode) {
+            case 1: // PURGE_MODE_DELETE
+                $purgeStatements = $this->getDeleteModeConnectionWithConsecutiveArguments($tables, $excludedTables);
+                break;
+            case 2: // PURGE_MODE_TRUNCATE
+                $purgeStatements = $this->getTruncateModeConnectionWithConsecutiveArguments($tables, $excludedTables);
+                break;
+            default:
+                break;
+        }
+
+        return array_merge(
+            [['SET FOREIGN_KEY_CHECKS=0']],
+            $purgeStatements,
+            [['SET FOREIGN_KEY_CHECKS=1']]
+        );
+    }
+
+    protected function getDeleteModeConnectionWithConsecutiveArguments(array $tables = self::TABLES, array $excludedTables = []): array
+    {
+        $return = [];
+
+        foreach ($tables as $tableName) {
+            if (!in_array($tableName, $excludedTables)) {
+                $return[] = [sprintf('DELETE FROM %s', $tableName)];
+            }
+        }
+
+        return $return;
+    }
+
+    protected function getTruncateModeConnectionWithConsecutiveArguments(array $tables = self::TABLES, array $excludedTables = []): array
+    {
+        $return = [];
+
+        foreach ($tables as $tableName) {
+            if (!in_array($tableName, $excludedTables)) {
+                $return[] = [sprintf('TRUNCATE %s', $tableName)];
+            }
+        }
+
+        return $return;
+    }
+}

--- a/tests/Purger/NonTransactionalConnectionPurgerTest.php
+++ b/tests/Purger/NonTransactionalConnectionPurgerTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Tests\Purger;
+
+use Doctrine\DBAL\Connection;
+use Exception;
+use Kununu\DataFixtures\Purger\NonTransactionalConnectionPurger;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class NonTransactionalConnectionPurgerTest extends ConnectionPurgerTestCase
+{
+    public function testThatPurgerIsNotTransactionalAndCommits(): void
+    {
+        /** @var MockObject|Connection $connection */
+        $connection = $this->getConnectionMock();
+
+        $connection
+            ->expects($this->exactly(5))
+            ->method($this->getExecuteQueryMethodName($connection))
+            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement())
+            ->willReturn(1);
+
+        $connection
+            ->expects($this->never())
+            ->method('beginTransaction');
+
+        $connection
+            ->expects($this->never())
+            ->method('commit');
+
+        $purger = new NonTransactionalConnectionPurger($connection);
+        $purger->purge();
+    }
+
+    public function testThatPurgerIsTransactionalAndRollbacks(): void
+    {
+        $this->expectException(Exception::class);
+
+        /** @var MockObject|Connection $connection */
+        $connection = $this->getConnectionMock();
+
+        $connection
+            ->expects($this->exactly(3))
+            ->method($this->getExecuteQueryMethodName($connection))
+            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement(1, ['table_1']))
+            ->willReturnCallback(function(string $sql): int {
+                if ('DELETE FROM table_1' === $sql) {
+                    throw new Exception();
+                }
+
+                return 1;
+            });
+
+        $connection
+            ->expects($this->never())
+            ->method('beginTransaction');
+
+        $connection
+            ->expects($this->never())
+            ->method('commit');
+
+        $connection
+            ->expects($this->never())
+            ->method('rollback');
+
+        $purger = new NonTransactionalConnectionPurger($connection);
+        $purger->purge();
+    }
+}


### PR DESCRIPTION
- Introduce NonTransactionalConnectionExecutor and NonTransactionalConnectionPurger for cases were we do not want to or can not execute transactional fixtures (e.g. DDL fixtures)

- Add tests to cover new classes

- Update documentation