### PR TITLE
Add `prepareDocument` to Elasticsearch fixtures

### DIFF
--- a/src/Adapter/ElasticSearchFixtureTrait.php
+++ b/src/Adapter/ElasticSearchFixtureTrait.php
@@ -17,11 +17,16 @@ trait ElasticSearchFixtureTrait
                 ],
             ];
 
-            $params[] = $document;
+            $params[] = $this->prepareDocument($document);
         }
 
         return $params;
     }
 
     abstract protected function getDocumentIdForBulkIndexation(array $document);
+
+    protected function prepareDocument(array $document): array
+    {
+        return $document;
+    }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to add `prepareDocument` to Elasticsearch fixtures to allow to change document before sending it to Elasticsearch

## Details
- You array of documents might have extra fields (e.g. for calculating the document id on Elasticsearch) that are not needed and/or allowed to be sent to Elasticsearch.
- The Elasticsearch fixtures now has a method called `prepareDocument` where you can unset/change whatever you need for each document array, before sending the data to ES
- You can then override the method in your fixture class to do that handling. By default is is returning the document as it is
