### PR TITLE
Fix Elasticsearch fixtures doc type to support older versions of Elasticsearch in bulk insert mode

### DIFF
--- a/docs/FixtureTypes/cache-pool-fixtures.md
+++ b/docs/FixtureTypes/cache-pool-fixtures.md
@@ -17,6 +17,9 @@ composer require psr/cache
 The first step to load Cache Pool Fixtures is to create fixtures classes. This classes must implement the [CachePoolFixtureInterface](/src/Adapter/CachePoolFixtureInterface.php).
 
 ```php
+<?php
+declare(strict_types=1);
+
 use Kununu\DataFixtures\Adapter\CachePoolFixtureInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -36,16 +39,25 @@ final class MyFixture implements CachePoolFixtureInterface
 In order to load the fixtures that you created in the previous step you will need to configure the CachePoolExecutor.
 
 ```php
-$memcached = new \Memcached();
+<?php
+declare(strict_types=1);
+
+use Kununu\DataFixtures\Executor\CachePoolExecutor;
+use Kununu\DataFixtures\Loader\CachePoolFixturesLoader;
+use Kununu\DataFixtures\Purger\CachePoolPurger;
+use Memcached;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+
+$memcached = new Memcached();
 $memcached->addServer('localhost', 11211);
 
-$cache = new Symfony\Component\Cache\Adapter\MemcachedAdapter($memcached);
+$cache = new MemcachedAdapter($memcached);
 
-$purger = new Kununu\DataFixtures\Purger\CachePoolPurger($cache);
+$purger = new CachePoolPurger($cache);
 
-$executor = new Kununu\DataFixtures\Executor\CachePoolExecutor($cache, $purger);
+$executor = new CachePoolExecutor($cache, $purger);
 
-$loader = new Kununu\DataFixtures\Loader\CachePoolFixturesLoader();
+$loader = new CachePoolFixturesLoader();
 $loader->addFixture(new MyFixture());
 
 $executor->execute($loader->getFixtures());
@@ -60,7 +72,12 @@ If you want to know more options on how you can load fixtures in the Loader chec
 By default, when loading fixtures the cache storage is purged. If you want to change this behavior and instead append the fixtures, you can pass *true* as second argument to the CachePoolExecutor.
 
 ```php
-$executor = new Kununu\DataFixtures\Executor\CachePoolExecutor($cache, $purger);
+<?php
+declare(strict_types=1);
+
+use Kununu\DataFixtures\Executor\CachePoolExecutor;
+
+$executor = new CachePoolExecutor($cache, $purger);
 
 // If you want you can `append` the fixtures instead of purging the cache storage
 $executor->execute($loader->getFixtures(), true);

--- a/docs/FixtureTypes/directory-loader.md
+++ b/docs/FixtureTypes/directory-loader.md
@@ -24,7 +24,7 @@ For any fixture extending this class:
 - All `*.php` files inside that directory will be loaded when invoking the `load` method of that fixture class.
   - Other files will be ignored.
 - Each of your `*.php` file should return an array of arrays, where each entry in the main array is a representation of the Elasticsearch document.
-- Your fixture class must also implement the `getDocumentIdForBulkIndexation` method as described in [Elasticsearch Fixtures](elasticsearch.md).
+- Your fixture class must also implement the `getDocumentIdForBulkIndexation` method, take into consideration the `prepareDocument` and `getDocumentType` methods, as described in [Elasticsearch Fixtures](elasticsearch.md).
 
 ## ElasticSearchJsonDirectoryFixture
 
@@ -36,7 +36,7 @@ For any fixture extending this class:
     - Other files will be ignored.
 - Each of your `*.json` file should be a JSON array of JSON objects, where each object in the main array is a representation of the Elasticsearch document.
 - Each file will be decoded to a PHP array, and from there the workflow is the same as `ElasticSearchArrayDirectoryFixture`.
-- Your fixture class must also implement the `getDocumentIdForBulkIndexation` method as described in [Elasticsearch Fixtures](elasticsearch.md).
+- Your fixture class must also implement the `getDocumentIdForBulkIndexation` method, take into consideration the `prepareDocument` and `getDocumentType` methods, as described in [Elasticsearch Fixtures](elasticsearch.md).
 
 ## HttpClientArrayDirectoryFixture
 

--- a/docs/FixtureTypes/doctrine-dbal-connection-fixtures.md
+++ b/docs/FixtureTypes/doctrine-dbal-connection-fixtures.md
@@ -19,6 +19,9 @@ The first step to load *Connection Fixtures* is to create fixtures classes.
 This classes must implement the [ConnectionFixtureInterface](/src/Adapter/ConnectionFixtureInterface.php) or extend the class [ConnectionSqlFixture](/src/Adapter/ConnectionSqlFixture.php) which allows you to define fixtures using *Sql* files.
 
 ```php
+<?php
+declare(strict_types=1);
+
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 
@@ -34,6 +37,9 @@ final class MyFixture implements ConnectionFixtureInterface
 ```
 
 ```php
+<?php
+declare(strict_types=1);
+
 use Kununu\DataFixtures\Adapter\ConnectionSqlFixture;
 
 final class MyFixtureSql extends ConnectionSqlFixture
@@ -66,19 +72,28 @@ INSERT INTO `database`.`table` (`id`, `name`, `description`) VALUES ('4', 'name4
 In order to load the fixtures that you created in the previous step you will need to configure the *Connection Executor*.
 
 ```php
-$config = new Doctrine\DBAL\Configuration();
+<?php
+declare(strict_types=1);
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\DriverManager;
+use Kununu\DataFixtures\Executor\ConnectionExecutor;
+use Kununu\DataFixtures\Loader\ConnectionFixturesLoader;
+use Kununu\DataFixtures\Purger\ConnectionPurger;
+
+$config = new Configuration();
 
 $connectionParams = [
     'url' => 'mysql://username:password@localhost/test_database'
 ];
 
-$conn = Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+$conn = DriverManager::getConnection($connectionParams, $config);
 
-$purger = new Kununu\DataFixtures\Purger\ConnectionPurger($conn);
+$purger = new ConnectionPurger($conn);
 
-$executor = new Kununu\DataFixtures\Executor\ConnectionExecutor($conn, $purger);
+$executor = new ConnectionExecutor($conn, $purger);
 
-$loader = new Kununu\DataFixtures\Loader\ConnectionFixturesLoader();
+$loader = new ConnectionFixturesLoader();
 $loader->addFixture(new MyFixtureSql());
 $loader->addFixture(new MyFixture());
 
@@ -92,7 +107,12 @@ If you want to know more options on how you can load fixtures in the Loader chec
 By default, when loading fixtures the database is purged. If you want to change this behavior and instead append the fixtures, you can pass *true* as second argument to the ConnectionExecutor.
 
 ```php
-$executor = new Kununu\DataFixtures\Executor\ConnectionExecutor($conn, $purger);
+<?php
+declare(strict_types=1);
+
+use Kununu\DataFixtures\Executor\ConnectionExecutor;
+
+$executor = new ConnectionExecutor($conn, $purger);
 
 // If you want you can `append` the fixtures instead of purging the database
 $executor->execute($loader->getFixtures(), true);
@@ -104,10 +124,16 @@ When you do not append fixtures all tables from the database are purged. Still, 
 You can specify the tables being excluded from being purged by passing them as second argument to the Purger.
 
 ```php
-$excludedTables = ['country_codes', 'doctrine_migrations'];
-$purger = new Kununu\DataFixtures\Purger\ConnectionPurger($conn, $excludedTables);
+<?php
+declare(strict_types=1);
 
-$executor = new Kununu\DataFixtures\Executor\ConnectionExecutor($conn, $purger);
+use Kununu\DataFixtures\Executor\ConnectionExecutor;
+use Kununu\DataFixtures\Purger\ConnectionPurger;
+
+$excludedTables = ['country_codes', 'doctrine_migrations'];
+$purger = new ConnectionPurger($conn, $excludedTables);
+
+$executor = new ConnectionExecutor($conn, $purger);
 
 $executor->execute($loader->getFixtures());
 ```
@@ -118,13 +144,16 @@ The Purger allows you to change the *Sql* statement used to purge the tables.
 By default, the Purger will run a *DELETE* statement to purge the tables but you can change it to use a *TRUNCATE* statement instead.
 
 ```php
-...
-$purger = new Kununu\DataFixtures\Purger\ConnectionPurger($conn, $excludedTables);
+<?php
+declare(strict_types=1);
+
+use Kununu\DataFixtures\Purger\ConnectionPurger;
+
+$purger = new ConnectionPurger($conn, $excludedTables);
 
 // If you want you can change the Purge Mode
 $purger->setPurgeMode(1); // PURGE_MODE_DELETE
 $purger->setPurgeMode(2); // PURGE_MODE_TRUNCATE
-
 ```
 
 ## Notes

--- a/docs/FixtureTypes/elasticsearch.md
+++ b/docs/FixtureTypes/elasticsearch.md
@@ -17,7 +17,12 @@ composer require elastic/elasticsearch
 The first step to load Elasticsearch Fixtures is to create fixtures classes. This classes must implement the [ElasticSearchFixtureInterface](/src/Adapter/ElasticSearchFixtureInterface.php) or if you want to easily use *bulk* inserts on your fixtures you can extend the class [ElasticSearchFixture](/src/Adapter/ElasticSearchFixture.php).
 
 
+#### Inserting a single document
+
 ```php
+<?php
+declare(strict_types=1);
+
 use Elasticsearch\Client;
 use Kununu\DataFixtures\Adapter\ElasticSearchFixtureInterface;
 
@@ -36,7 +41,12 @@ final class MyFixture implements ElasticSearchFixtureInterface
 }
 ```
 
+#### Bulk inserting documents
+
 ```php
+<?php
+declare(strict_types=1);
+
 use Elasticsearch\Client;
 use Kununu\DataFixtures\Adapter\ElasticSearchFixture;
 
@@ -46,6 +56,7 @@ final class MyFixture extends ElasticSearchFixture
     {
         $elasticSearch->bulk(
             [
+                // Some older versions of Elasticsearch requires the type
                 'type' => '_doc',
                 'body' => $this->prepareBodyForBulkIndexation($indexName, $this->getYourDocuments()),
             ]
@@ -58,7 +69,30 @@ final class MyFixture extends ElasticSearchFixture
      */
     protected function getDocumentIdForBulkIndexation(array $document)
     {
-        return $document['id'];
+        return sprintf('%d_%s', $document['id'], $document['doc_type']) ;
+    }
+    
+    /**
+     * Implement this method to change the document structure before sending it to Elasticsearch (e.g. for removing
+     * fields that are in your document array but should not go to Elastic).
+     * If not overridden it will by default returns the document unchanged.  
+     */
+    protected function prepareDocument(array $document) : array
+    {
+        // In this example we don't want to send the 'doc_type' field because it is only being used to generate the
+        // document id
+        unset($document['doc_type']);
+        
+        return $document;
+    }
+    
+    /**
+     * Some older versions of Elasticsearch require the "_type" attribute on each document sent to bulk insert.
+     * By default, this is returning null but if you ES version requires this, then return it here   
+     */
+    protected function getDocumentType() : ?string
+    {
+        return '_doc';
     }
 
     /**
@@ -70,14 +104,210 @@ final class MyFixture extends ElasticSearchFixture
             [
                 'id'        => 1,
                 'doc_field' => 'Document 1',
+                'doc_type' => 'invoice',
             ],
             [
                 'id'        => 2,
                 'doc_field' => 'Document 2',
+                'doc_type' => 'receipt',
             ],
         ];
     }
 }
+```
+
+#### Bulk insert documents from files
+
+To include a series of files extend `Kununu\DataFixtures\Adapter\ElasticSearchFileFixture`.
+
+There are two options here:
+
+- Each file return an array of PHP files with the documents
+- Each file has a JSON representation of an array of documents
+
+Your fixtures class should implement the following methods:
+
+- `protected function fileNames(): array;`
+
+Get the files to load
+
+- `protected function getFileExtension(): string;`
+
+Get the file extension (should return `php` for PHP array files or `json` for JSON file)
+
+- `protected function getLoadMode(): string;`
+
+The load method to use.
+- `AbstractFileLoaderFixture::LOAD_MODE_INCLUDE` to include the PHP array files
+- `AbstractFileLoaderFixture::LOAD_MODE_LOAD_JSON` to load and convert the JSON files to array
+
+Example:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Elasticsearch\Client;
+use Kununu\DataFixtures\Adapter\ElasticSearchFileFixture;
+
+final class MyFixture extends ElasticSearchFileFixture
+{
+	protected function fileNames(): array
+	{
+		// Load data from the following files
+		return [
+			__DIR__. '/Elastisearch/fixture1.php';
+		];
+	}
+	
+    protected function getFileExtension(): string
+    {
+		// Only load *.php files
+        return 'php';
+    }
+
+    protected function getLoadMode(): string
+    {
+		// Load the php files as includes
+        return self::LOAD_MODE_INCLUDE;
+    }
+
+    /**
+     * Implement this method to retrieve the document id on Elasticsearch from the document array
+     * (or generate one)
+     */
+    protected function getDocumentIdForBulkIndexation(array $document)
+    {
+        return sprintf('%d_%s', $document['id'], $document['doc_type']) ;
+    }
+    
+    /**
+     * Implement this method to change the document structure before sending it to Elasticsearch (e.g. for removing
+     * fields that are in your document array but should not go to Elastic).
+     * If not overridden it will by default returns the document unchanged.  
+     */
+    protected function prepareDocument(array $document) : array
+    {
+        // In this example we don't want to send the 'doc_type' field because it is only being used to generate the
+        // document id
+        unset($document['doc_type']);
+        
+        return $document;
+    }
+    
+    /**
+     * Some older versions of Elasticsearch require the "_type" attribute on each document sent to bulk insert.
+     * By default, this is returning null but if you ES version requires this, then return it here   
+     */
+    protected function getDocumentType() : ?string
+    {
+        return '_doc';
+    }
+}
+```
+
+Or for JSON files:
+
+```php
+<?php
+declare(strict_types=1);
+
+use Elasticsearch\Client;
+use Kununu\DataFixtures\Adapter\ElasticSearchFileFixture;
+
+final class MyFixture extends ElasticSearchFileFixture
+{
+	protected function fileNames(): array
+	{
+		// Load data from the following files
+		return [
+			__DIR__. '/Elastisearch/fixture1.json';
+		];
+	}
+	
+    protected function getFileExtension(): string
+    {
+		// Only load *.json files
+        return 'json';
+    }
+
+    protected function getLoadMode(): string
+    {
+		// Load the json files contents as arrays
+        return self::LOAD_MODE_LOAD_JSON;
+    }
+
+    /**
+     * Implement this method to retrieve the document id on Elasticsearch from the document array
+     * (or generate one)
+     */
+    protected function getDocumentIdForBulkIndexation(array $document)
+    {
+        return sprintf('%d_%s', $document['id'], $document['doc_type']) ;
+    }
+    
+    /**
+     * Implement this method to change the document structure before sending it to Elasticsearch (e.g. for removing
+     * fields that are in your document array but should not go to Elastic).
+     * If not overridden it will by default returns the document unchanged.  
+     */
+    protected function prepareDocument(array $document) : array
+    {
+        // In this example we don't want to send the 'doc_type' field because it is only being used to generate the
+        // document id
+        unset($document['doc_type']);
+        
+        return $document;
+    }
+    
+    /**
+     * Some older versions of Elasticsearch require the "_type" attribute on each document sent to bulk insert.
+     * By default, this is returning null but if you ES version requires this, then return it here   
+     */
+    protected function getDocumentType() : ?string
+    {
+        return '_doc';
+    }
+}
+```
+
+*Fixtures files:*
+
+##### fixture1.php
+
+```php
+<?php
+declare(strict_types=1);
+
+return [
+    [
+        'id'        => 1,
+        'doc_field' => 'Document 1',
+        'doc_type' => 'invoice',
+    ],
+    [
+        'id'        => 2,
+        'doc_field' => 'Document 2',
+        'doc_type' => 'receipt',
+    ],
+];
+```
+
+##### fixture1.json
+
+```json
+[
+    {
+        "id": 1,
+        "doc_field": "Document 1",
+        "doc_type": "invoice"
+    },
+    {
+        "id": 2,
+        "doc_field": "Document 2",
+        "doc_type": "receipt"
+    }
+]
 ```
 
 ### 2. Load fixtures
@@ -85,13 +315,21 @@ final class MyFixture extends ElasticSearchFixture
 In order to load the fixtures that you created in the previous step you will need to configure the *Elasticsearch Executor*.
 
 ```php
-$client = \Elasticsearch\ClientBuilder::create()->build();
+<?php
+declare(strict_types=1);
 
-$purger = new \Kununu\DataFixtures\Purger\ElasticSearchPurger($client, 'my_index');
+use Elasticsearch\ClientBuilder;
+use Kununu\DataFixtures\Executor\ElasticSearchExecutor;
+use Kununu\DataFixtures\Loader\ElasticSearchFixturesLoader;
+use Kununu\DataFixtures\Purger\ElasticSearchPurger;
 
-$executor = new \Kununu\DataFixtures\Executor\ElasticSearchExecutor($client, 'my_index', $purger);
+$client = ClientBuilder::create()->build();
 
-$loader = new \Kununu\DataFixtures\Loader\ElasticSearchFixturesLoader();
+$purger = new ElasticSearchPurger($client, 'my_index');
+
+$executor = new ElasticSearchExecutor($client, 'my_index', $purger);
+
+$loader = new ElasticSearchFixturesLoader();
 $loader->addFixture(new MyFixture());
 
 $executor->execute($loader->getFixtures());
@@ -107,7 +345,12 @@ If you want to know more options on how you can load fixtures in the Loader chec
 By default, when loading fixtures the Elasticsearch index is purged. If you want to change this behavior and instead append the fixtures, you can pass *true* as second argument to the ElasticsearchExecutor.
 
 ```php
-$executor = new \Kununu\DataFixtures\Executor\ElasticSearchExecutor($client, 'my_index', $purger);
+<?php
+declare(strict_types=1);
+
+use Kununu\DataFixtures\Executor\ElasticSearchExecutor;
+
+$executor = new ElasticSearchExecutor($client, 'my_index', $purger);
 
 // If you want you can `append` the fixtures instead of purging the Elasticsearch index
 $executor->execute($loader->getFixtures(), true);

--- a/docs/FixtureTypes/symfony-http-client.md
+++ b/docs/FixtureTypes/symfony-http-client.md
@@ -25,6 +25,9 @@ want to easily define an array of requests/responses on your fixtures you can ex
 class [HttpClientPhpArrayFixture](/src/Adapter/HttpClientPhpArrayFixture.php).
 
 ```php
+<?php
+declare(strict_types=1);
+
 use Kununu\DataFixtures\Adapter\HttpClientPhpArrayFixture;
 
 final class MyFixture extends HttpClientPhpArrayFixture
@@ -88,6 +91,9 @@ Note that you **need to** use the special [HttpClient](/src/Tools/HttpClient) pr
 on Symfony **MockHttpClient**.
 
 ```php
+<?php
+declare(strict_types=1);
+
 use Kununu\DataFixtures\Executor\HttpClientExecutor;
 use Kununu\DataFixtures\Loader\HttpClientFixturesLoader;
 use Kununu\DataFixtures\Purger\HttpClientPurger;

--- a/docs/how-to-create-new-fixture-type.md
+++ b/docs/how-to-create-new-fixture-type.md
@@ -6,6 +6,7 @@ You can find the list of all supported storage types [here](/README.md#Fixtures-
 Still, if you have the need to create a new type you can do it and it's pretty simple.
 
 For example, let's imagine that you need to load fixtures (in this case files) to a specific directory. To get this new type of fixtures up and running you will need to create a set of elements:
+
 - [Fixture Interface](#Create-fixture-type-interface)
 - [Purger](#Create-Purger)
 - [Loader](#Create-Loader)
@@ -211,15 +212,21 @@ declare(strict_types=1);
 
 require __DIR__ . '/vendor/autoload.php';
 
+use Kununu\DataFixtures\Purger\DirectoryPurger;
+use Kununu\DataFixtures\Executor\DirectoryExecutor;
+use Kununu\DataFixtures\Loader\DirectoryFixturesLoader;
+use Kununu\DataFixtures\DirectoryFixture1;
+use Kununu\DataFixtures\DirectoryFixture2;
+
 $dirname = sprintf('%s/temp', __DIR__);
 
-$purger = new \Kununu\DataFixtures\Purger\DirectoryPurger($dirname);
+$purger = new DirectoryPurger($dirname);
 
-$executor = new Kununu\DataFixtures\Executor\DirectoryExecutor($dirname, $purger);
+$executor = new DirectoryExecutor($dirname, $purger);
 
-$loader = new Kununu\DataFixtures\Loader\DirectoryFixturesLoader();
-$loader->addFixture(new \Kununu\DataFixtures\DirectoryFixture1());
-$loader->addFixture(new \Kununu\DataFixtures\DirectoryFixture2());
+$loader = new DirectoryFixturesLoader();
+$loader->addFixture(new DirectoryFixture1());
+$loader->addFixture(new DirectoryFixture2());
 
 $executor->execute($loader->getFixtures());
 

--- a/src/Adapter/ElasticSearchFileFixture.php
+++ b/src/Adapter/ElasticSearchFileFixture.php
@@ -26,9 +26,4 @@ abstract class ElasticSearchFileFixture extends AbstractFileLoaderFixture implem
             }
         );
     }
-
-    protected function getDocumentType(): ?string
-    {
-        return '_doc';
-    }
 }

--- a/src/Adapter/ElasticSearchFixtureTrait.php
+++ b/src/Adapter/ElasticSearchFixtureTrait.php
@@ -11,10 +11,13 @@ trait ElasticSearchFixtureTrait
 
         foreach ($documents as $document) {
             $params[] = [
-                'index' => [
-                    '_index' => $indexName,
-                    '_id'    => $this->getDocumentIdForBulkIndexation($document),
-                ],
+                'index' => array_merge(
+                    [
+                        '_index' => $indexName,
+                        '_id'    => $this->getDocumentIdForBulkIndexation($document),
+                    ],
+                    is_string($documentType = $this->getDocumentType()) ? ['_type' => $documentType] : []
+                ),
             ];
 
             $params[] = $this->prepareDocument($document);
@@ -28,5 +31,10 @@ trait ElasticSearchFixtureTrait
     protected function prepareDocument(array $document): array
     {
         return $document;
+    }
+
+    protected function getDocumentType(): ?string
+    {
+        return null;
     }
 }

--- a/src/Tools/ConnectionToolsTrait.php
+++ b/src/Tools/ConnectionToolsTrait.php
@@ -13,21 +13,17 @@ trait ConnectionToolsTrait
     protected function getDatabaseTables(Connection $connection): array
     {
         // This way we support both doctrine/dbal ^2.9 and ^3.1
-        if (method_exists($connection, 'createSchemaManager')) {
-            return $connection->createSchemaManager()->listTableNames();
-        }
+        $method = method_exists($connection, 'createSchemaManager') ? 'createSchemaManager' : 'getSchemaManager';
 
-        return $connection->getSchemaManager()->listTableNames();
+        return $connection->$method()->listTableNames();
     }
 
     protected function executeQuery(Connection $connection, string $sql): int
     {
         // This way we support both doctrine/dbal ^2.9 and ^3.1
-        if (method_exists($connection, 'executeStatement')) {
-            return $connection->executeStatement($sql);
-        }
+        $method = method_exists($connection, 'executeStatement') ? 'executeStatement' : 'exec';
 
-        return $connection->exec($sql);
+        return $connection->$method($sql);
     }
 
     protected function getDisableForeignKeysChecksStatementByDriver(Driver $driver): string

--- a/tests/Adapter/ElasticSearchArrayDirectoryFixtureTest.php
+++ b/tests/Adapter/ElasticSearchArrayDirectoryFixtureTest.php
@@ -27,6 +27,7 @@ final class ElasticSearchArrayDirectoryFixtureTest extends TestCase
                                 'index' => [
                                     '_index' => 'my_index',
                                     '_id'    => 1,
+                                    '_type'  => '_doc',
                                 ],
                             ],
                             [
@@ -42,6 +43,7 @@ final class ElasticSearchArrayDirectoryFixtureTest extends TestCase
                                 'index' => [
                                     '_index' => 'my_index',
                                     '_id'    => 2,
+                                    '_type'  => '_doc',
                                 ],
                             ],
                             [
@@ -64,6 +66,7 @@ final class ElasticSearchArrayDirectoryFixtureTest extends TestCase
                                 'index' => [
                                     '_index' => 'my_index',
                                     '_id'    => 3,
+                                    '_type'  => '_doc',
                                 ],
                             ],
                             [

--- a/tests/Adapter/ElasticSearchJsonDirectoryFixtureTest.php
+++ b/tests/Adapter/ElasticSearchJsonDirectoryFixtureTest.php
@@ -23,7 +23,6 @@ final class ElasticSearchJsonDirectoryFixtureTest extends TestCase
             ->withConsecutive(
                 [
                     [
-                        'type' => '_doc',
                         'body' => [
                             [
                                 'index' => [
@@ -60,7 +59,6 @@ final class ElasticSearchJsonDirectoryFixtureTest extends TestCase
                 ],
                 [
                     [
-                        'type' => '_doc',
                         'body' => [
                             [
                                 'index' => [
@@ -91,7 +89,6 @@ final class ElasticSearchJsonDirectoryFixtureTest extends TestCase
             ->expects($this->once())
             ->method('bulk')
             ->with([
-                'type' => '_doc',
                 'body' => [
                     [
                         'index' => [

--- a/tests/TestFixtures/ElasticSearchArrayDirectoryFixture1.php
+++ b/tests/TestFixtures/ElasticSearchArrayDirectoryFixture1.php
@@ -11,4 +11,9 @@ final class ElasticSearchArrayDirectoryFixture1 extends ElasticSearchArrayDirect
     {
         return $document['id'];
     }
+
+    protected function getDocumentType(): ?string
+    {
+        return '_doc';
+    }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to fix Elasticsearch fixtures doc type to support older versions of Elasticsearch in bulk insert mode.

## Details

When using bulk insert for older versions of Elasticsearch (e.g. 6.4) it is required to send the `_type` of each document (in newer versions this in fact issue a deprecation warning or an error).

This PR fixes that by adding the `getDocumentType` method to Elastiscsearch fixtures (defaulting it to null) so that you can override this on your fixture classes to avoid the error when that parameter is required.