### PR TITLE
Drop support for PHP 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.0",
         "ext-json": "*"
     },
     "keywords": [
@@ -27,7 +27,7 @@
     "require-dev": {
         "doctrine/dbal": "^2.9 || ^3.1",
         "elasticsearch/elasticsearch": "^7.0",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9.5",
         "psr/cache": "^1.0",
         "symfony/phpunit-bridge": "^5.2",
         "symfony/http-client": "^4.4 | ^5.2",

--- a/docs/how-to-create-new-fixture-type.md
+++ b/docs/how-to-create-new-fixture-type.md
@@ -3,7 +3,7 @@
 This package already provides implementations to load fixtures for some storage types.
 
 You can find the list of all supported storage types [here](/README.md#Fixtures-types).
-Still, if you have the need to create a new type you can do it and it's pretty simple.
+Still, if you have the need to create a new type you can do it, and it's pretty simple.
 
 For example, let's imagine that you need to load fixtures (in this case files) to a specific directory. To get this new type of fixtures up and running you will need to create a set of elements:
 

--- a/docs/why-kununu-data-fixtures.md
+++ b/docs/why-kununu-data-fixtures.md
@@ -1,8 +1,19 @@
 # Why kununu/data-fixtures
 
-At kununu we have the need to easily load fixtures for any of the storages that our services usually rely on: MySQL, Elasticsearch, Memcached, etc. We looked into community packages and there are definitily great options however we realized that they do not fullfill all of our requirements:
+At kununu we have the need to easily load fixtures for any of the storages that our services usually rely on: MySQL, Elasticsearch, Memcached, etc.
 
-- **We don't want to depend on Doctrine ORM** - [Doctrine ORM](https://www.doctrine-project.org/projects/orm.html) it's great, still in order to ease the writing of the fixtures we can easily end up with Anemic Domain Models with a bunch of setters in our entities. Another point that we had into consideration is that we have services that do not rely on Doctrine ORM and use the Doctrine DBAL directly. With this two points we had no other choice than drop [doctrine/data-fixtures](https://github.com/doctrine/data-fixtures) as an option.
-- **Database schema is not touched when loading fixtures** - When we use Doctrine ORM we map our entities and generate migrations using Doctrine Migrations out of those mappings. Still, we have cases which Doctrine ORM does not support, like Virtual Columns, and as such we cannot recreated the database easily when we load fixtures. With this point we had no other choice than drop [liip/LiipTestFixturesBundle](https://github.com/liip/LiipTestFixturesBundle) as an option.
-- **We really want to hit the database** - The approach of the package [dmaicher/doctrine-test-bundle](https://github.com/dmaicher/doctrine-test-bundle) is to begin a transaction before every test case and roll it back again after the test finishes. This is definitely a valid approach, still by actually hit the database we are sure we cover the whole integration even if it means a small performance penalty.
-- **We would like to have the same approach for all storages** - No matter the storage that we load fixtures into, we want to have the same behavior making it easier to reason about.
+We looked into community packages and there are definitely great options however we realized that they do not fulfill all of our requirements:
+
+- **We don't want to depend on Doctrine ORM**
+  - [Doctrine ORM](https://www.doctrine-project.org/projects/orm.html) it's great, still in order to ease the writing of the fixtures we can easily end up with Anemic Domain Models with a bunch of setters in our entities.
+  - Another point that we had into consideration is that we have services that do not rely on Doctrine ORM and use the Doctrine DBAL directly.
+  - With this two points we had no other choice than drop [doctrine/data-fixtures](https://github.com/doctrine/data-fixtures) as an option.
+- **Database schema is not touched when loading fixtures**
+  - When we use Doctrine ORM we map our entities and generate migrations using Doctrine Migrations out of those mappings.
+  - Still, we have cases which Doctrine ORM does not support, like Virtual Columns, and as such we cannot recreate the database easily when we load fixtures.
+  - With this point we had no other choice than drop [liip/LiipTestFixturesBundle](https://github.com/liip/LiipTestFixturesBundle) as an option.
+- **We really want to hit the database**
+  - The approach of the package [dmaicher/doctrine-test-bundle](https://github.com/dmaicher/doctrine-test-bundle) is to begin a transaction before every test case and roll it back again after the test finishes.
+  - This is definitely a valid approach, still by actually hit the database we are sure we cover the whole integration even if it means a small performance penalty.
+- **We would like to have the same approach for all storages**
+  - No matter the storage that we load fixtures into, we want to have the same behavior making it easier to reason about.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="vendor/autoload.php"
-        colors="true"
-        beStrictAboutChangesToGlobalState="true">
+<!-- https://phpunit.readthedocs.io/en/9.6/ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="vendor/autoload.php"
+         colors="true" beStrictAboutChangesToGlobalState="true">
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+        <report>
+            <clover outputFile="tests/.results/tests-clover.xml"/>
+            <html outputDirectory="tests/.results/html/"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="DataFixtures Test Suite">
-            <directory>./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
-
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
-
     <logging>
-        <log type="coverage-clover" target="tests/.results/tests-clover.xml"/>
-        <log type="junit" target="tests/.results/tests-junit.xml"/>
-        <log type="coverage-html" target="tests/.results/html/"/>
+        <junit outputFile="tests/.results/tests-junit.xml"/>
     </logging>
 </phpunit>

--- a/src/Adapter/ConnectionSqlFixture.php
+++ b/src/Adapter/ConnectionSqlFixture.php
@@ -12,10 +12,9 @@ abstract class ConnectionSqlFixture extends AbstractFileLoaderFixture implements
 
     final public function load(Connection $connection): void
     {
-        parent::loadFiles(function(?string $sql) use ($connection): void {
-            if (is_string($sql)) {
-                $this->executeQuery($connection, $sql);
-            }
+        parent::loadFiles(fn (?string $sql) => match (true) {
+            is_string($sql) => $this->executeQuery($connection, $sql),
+            default         => null
         });
     }
 

--- a/src/Adapter/DirectoryLoader/DirectoryFileSearchTrait.php
+++ b/src/Adapter/DirectoryLoader/DirectoryFileSearchTrait.php
@@ -12,17 +12,16 @@ trait DirectoryFileSearchTrait
         return $this->searchFileNames($this->getFileExtension(), $this->getDirectory());
     }
 
-    abstract protected function getFileExtension(): string;
-
-    abstract protected function getDirectory(): string;
-
     protected function searchFileNames(string $extension, string $subDirectory): array
     {
         $root = $this->root($subDirectory);
         $files = [];
         if ($handle = opendir($root)) {
             while (false !== ($file = readdir($handle))) {
-                if ('.' !== $file && '..' !== $file && $extension === strtolower(substr($file, strrpos($file, '.') + 1))) {
+                if ('.' !== $file &&
+                    '..' !== $file &&
+                    $extension === strtolower(substr($file, strrpos($file, '.') + 1))
+                ) {
                     $files[] = sprintf('%s/%s', $root, $file);
                 }
             }
@@ -32,6 +31,10 @@ trait DirectoryFileSearchTrait
 
         return $files;
     }
+
+    abstract protected function getFileExtension(): string;
+
+    abstract protected function getDirectory(): string;
 
     private function root(string $subDirectory): string
     {

--- a/src/Adapter/ElasticSearchFileFixture.php
+++ b/src/Adapter/ElasticSearchFileFixture.php
@@ -9,20 +9,17 @@ abstract class ElasticSearchFileFixture extends AbstractFileLoaderFixture implem
 {
     use ElasticSearchFixtureTrait;
 
-    final public function load(Client $elasticSearch, string $indexName): void
+    public function load(Client $elasticSearch, string $indexName): void
     {
         parent::loadFiles(
-            function(array $documents) use ($elasticSearch, $indexName): void {
-                if (empty($documents)) {
-                    return;
-                }
-
-                $elasticSearch->bulk(
+            fn (array $documents) => match (true) {
+                empty($documents) => null,
+                default           => $elasticSearch->bulk(
                     array_merge(
                         ['body' => $this->prepareBodyForBulkIndexation($indexName, $documents)],
                         is_string($documentType = $this->getDocumentType()) ? ['type' => $documentType] : []
                     )
-                );
+                )
             }
         );
     }

--- a/src/Adapter/ElasticSearchFixtureTrait.php
+++ b/src/Adapter/ElasticSearchFixtureTrait.php
@@ -26,8 +26,6 @@ trait ElasticSearchFixtureTrait
         return $params;
     }
 
-    abstract protected function getDocumentIdForBulkIndexation(array $document);
-
     protected function prepareDocument(array $document): array
     {
         return $document;
@@ -37,4 +35,6 @@ trait ElasticSearchFixtureTrait
     {
         return null;
     }
+
+    abstract protected function getDocumentIdForBulkIndexation(array $document);
 }

--- a/src/Adapter/HttpClientPhpArrayFixture.php
+++ b/src/Adapter/HttpClientPhpArrayFixture.php
@@ -14,9 +14,7 @@ abstract class HttpClientPhpArrayFixture extends AbstractFileLoaderFixture imple
             return;
         }
 
-        parent::loadFiles(function(array $responses) use ($httpClient): void {
-            $httpClient->addResponses($responses);
-        });
+        parent::loadFiles(fn (array $responses) => $httpClient->addResponses($responses));
     }
 
     protected function getFileExtension(): string

--- a/src/Executor/CachePoolExecutor.php
+++ b/src/Executor/CachePoolExecutor.php
@@ -9,13 +9,8 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class CachePoolExecutor implements ExecutorInterface
 {
-    private $cache;
-    private $purger;
-
-    public function __construct(CacheItemPoolInterface $cache, PurgerInterface $purger)
+    public function __construct(private CacheItemPoolInterface $cache, private PurgerInterface $purger)
     {
-        $this->cache = $cache;
-        $this->purger = $purger;
     }
 
     public function execute(array $fixtures, bool $append = false): void

--- a/src/Executor/ConnectionExecutor.php
+++ b/src/Executor/ConnectionExecutor.php
@@ -13,18 +13,14 @@ final class ConnectionExecutor implements ExecutorInterface
 {
     use ConnectionToolsTrait;
 
-    private $connection;
-    private $purger;
-    private $transactional;
-
-    public function __construct(Connection $connection, PurgerInterface $purger, bool $transactional = true)
-    {
-        $this->connection = $connection;
-        $this->purger = $purger;
-        $this->transactional = $transactional;
+    public function __construct(
+        private Connection $connection,
+        private PurgerInterface $purger,
+        private bool $transactional = true
+    ) {
     }
 
-    public function execute(array $fixtures, $append = false): void
+    public function execute(array $fixtures, bool $append = false): void
     {
         if ($this->transactional) {
             $this->connection->beginTransaction();
@@ -35,7 +31,10 @@ final class ConnectionExecutor implements ExecutorInterface
                 $this->purger->purge();
             }
 
-            $this->executeQuery($this->connection, $this->getDisableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
+            $this->executeQuery(
+                $this->connection,
+                $this->getDisableForeignKeysChecksStatementByDriver($this->connection->getDriver())
+            );
 
             foreach ($fixtures as $fixture) {
                 $this->load($fixture);
@@ -50,7 +49,10 @@ final class ConnectionExecutor implements ExecutorInterface
             }
             throw $e;
         } finally {
-            $this->executeQuery($this->connection, $this->getEnableForeignKeysChecksStatementByDriver($this->connection->getDriver()));
+            $this->executeQuery(
+                $this->connection,
+                $this->getEnableForeignKeysChecksStatementByDriver($this->connection->getDriver())
+            );
         }
     }
 

--- a/src/Executor/ElasticSearchExecutor.php
+++ b/src/Executor/ElasticSearchExecutor.php
@@ -9,15 +9,11 @@ use Kununu\DataFixtures\Purger\PurgerInterface;
 
 final class ElasticSearchExecutor implements ExecutorInterface
 {
-    private $elasticSearch;
-    private $indexName;
-    private $purger;
-
-    public function __construct(Client $elasticSearch, string $indexName, PurgerInterface $purger)
-    {
-        $this->elasticSearch = $elasticSearch;
-        $this->indexName = $indexName;
-        $this->purger = $purger;
+    public function __construct(
+        private Client $elasticSearch,
+        private string $indexName,
+        private PurgerInterface $purger
+    ) {
     }
 
     public function execute(array $fixtures, bool $append = false): void

--- a/src/Executor/HttpClientExecutor.php
+++ b/src/Executor/HttpClientExecutor.php
@@ -9,13 +9,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class HttpClientExecutor implements ExecutorInterface
 {
-    private $httpClient;
-    private $purger;
-
-    public function __construct(HttpClientInterface $httpClient, PurgerInterface $purger)
+    public function __construct(private HttpClientInterface $httpClient, private PurgerInterface $purger)
     {
-        $this->httpClient = $httpClient;
-        $this->purger = $purger;
     }
 
     public function execute(array $fixtures, bool $append = false): void

--- a/src/Executor/NonTransactionalConnectionExecutor.php
+++ b/src/Executor/NonTransactionalConnectionExecutor.php
@@ -8,14 +8,14 @@ use Kununu\DataFixtures\Purger\PurgerInterface;
 
 final class NonTransactionalConnectionExecutor implements ExecutorInterface
 {
-    private $executor;
+    private ExecutorInterface $executor;
 
     public function __construct(Connection $connection, PurgerInterface $purger)
     {
         $this->executor = new ConnectionExecutor($connection, $purger, false);
     }
 
-    public function execute(array $fixtures, $append = false): void
+    public function execute(array $fixtures, bool $append = false): void
     {
         $this->executor->execute($fixtures, $append);
     }

--- a/src/InitializableFixtureInterface.php
+++ b/src/InitializableFixtureInterface.php
@@ -5,5 +5,5 @@ namespace Kununu\DataFixtures;
 
 interface InitializableFixtureInterface
 {
-    public function initializeFixture(...$args): void;
+    public function initializeFixture(mixed ...$args): void;
 }

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -3,32 +3,25 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Loader;
 
-use ArrayIterator;
-use InvalidArgumentException;
-use Iterator;
 use Kununu\DataFixtures\FixtureInterface;
 use Kununu\DataFixtures\InitializableFixtureInterface;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use ReflectionClass;
-use SplFileInfo;
 
 abstract class Loader implements LoaderInterface
 {
     private const FILE_EXTENSION = '.php';
 
-    private $fixtures = [];
-    private $initalizableFixtures = [];
+    private array $fixtures = [];
+    private array $initalizableFixtures = [];
 
     final public function loadFromDirectory(string $dir): void
     {
         if (!is_dir($dir)) {
-            throw new InvalidArgumentException(sprintf('"%s" does not exist', $dir));
+            throw new \InvalidArgumentException(sprintf('"%s" does not exist', $dir));
         }
 
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir),
-            RecursiveIteratorIterator::LEAVES_ONLY
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir),
+            \RecursiveIteratorIterator::LEAVES_ONLY
         );
 
         $this->loadFromIterator($iterator);
@@ -37,22 +30,22 @@ abstract class Loader implements LoaderInterface
     final public function loadFromFile(string $fileName): void
     {
         if (!is_readable($fileName)) {
-            throw new InvalidArgumentException(sprintf('"%s" does not exist or is not readable', $fileName));
+            throw new \InvalidArgumentException(sprintf('"%s" does not exist or is not readable', $fileName));
         }
 
-        $this->loadFromIterator(new ArrayIterator([new SplFileInfo($fileName)]));
+        $this->loadFromIterator(new \ArrayIterator([new \SplFileInfo($fileName)]));
     }
 
     final public function loadFromClassName(string $className): void
     {
-        $reflClass = new ReflectionClass($className);
-        $this->loadFromIterator(new ArrayIterator([new SplFileInfo($reflClass->getFileName())]));
+        $reflClass = new \ReflectionClass($className);
+        $this->loadFromIterator(new \ArrayIterator([new \SplFileInfo($reflClass->getFileName())]));
     }
 
     final public function getFixture(string $className): FixtureInterface
     {
         if (!isset($this->fixtures[$className])) {
-            throw new InvalidArgumentException(sprintf('"%s" is not a registered fixture', $className));
+            throw new \InvalidArgumentException(sprintf('"%s" is not a registered fixture', $className));
         }
 
         return $this->fixtures[$className];
@@ -60,9 +53,7 @@ abstract class Loader implements LoaderInterface
 
     final public function addFixture(FixtureInterface $fixture): void
     {
-        $fixtureClass = get_class($fixture);
-
-        if (!isset($this->fixtures[$fixtureClass])) {
+        if (!isset($this->fixtures[$fixtureClass = $fixture::class])) {
             $this->fixtures[$fixtureClass] = $fixture;
         }
     }
@@ -72,7 +63,7 @@ abstract class Loader implements LoaderInterface
         return $this->fixtures;
     }
 
-    final public function registerInitializableFixture(string $className, ...$args): void
+    final public function registerInitializableFixture(string $className, mixed ...$args): void
     {
         if (!isset($this->initalizableFixtures[$className])) {
             $this->initalizableFixtures[$className] = $args;
@@ -99,7 +90,7 @@ abstract class Loader implements LoaderInterface
         return $class;
     }
 
-    private function loadFromIterator(Iterator $iterator): void
+    private function loadFromIterator(\Iterator $iterator): void
     {
         $includedFiles = [];
         foreach ($iterator as $file) {
@@ -117,7 +108,7 @@ abstract class Loader implements LoaderInterface
         sort($declared);
 
         foreach ($declared as $className) {
-            $reflClass = new ReflectionClass($className);
+            $reflClass = new \ReflectionClass($className);
             $sourceFile = $reflClass->getFileName();
 
             if (in_array($sourceFile, $includedFiles) && $this->supports($className)) {

--- a/src/Loader/LoaderInterface.php
+++ b/src/Loader/LoaderInterface.php
@@ -19,7 +19,7 @@ interface LoaderInterface
 
     public function getFixtures(): array;
 
-    public function registerInitializableFixture(string $className, ...$args): void;
+    public function registerInitializableFixture(string $className, mixed ...$args): void;
 
     public function clearFixtures(): void;
 }

--- a/src/Purger/CachePoolPurger.php
+++ b/src/Purger/CachePoolPurger.php
@@ -8,17 +8,14 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class CachePoolPurger implements PurgerInterface
 {
-    private $cachePool;
-
-    public function __construct(CacheItemPoolInterface $cachePool)
+    public function __construct(private CacheItemPoolInterface $cachePool)
     {
-        $this->cachePool = $cachePool;
     }
 
     public function purge(): void
     {
         if (!$this->cachePool->clear()) {
-            throw new PurgeFailedException(sprintf('Failed to purge cache pool "%s"', get_class($this->cachePool)));
+            throw new PurgeFailedException(sprintf('Failed to purge cache pool "%s"', $this->cachePool::class));
         }
     }
 }

--- a/src/Purger/ElasticSearchPurger.php
+++ b/src/Purger/ElasticSearchPurger.php
@@ -8,13 +8,8 @@ use stdClass;
 
 final class ElasticSearchPurger implements PurgerInterface
 {
-    private $elasticSearch;
-    private $indexName;
-
-    public function __construct(Client $elasticSearch, string $indexName)
+    public function __construct(private Client $elasticSearch, private string $indexName)
     {
-        $this->elasticSearch = $elasticSearch;
-        $this->indexName = $indexName;
     }
 
     public function purge(): void
@@ -24,8 +19,8 @@ final class ElasticSearchPurger implements PurgerInterface
 
         $this->elasticSearch->deleteByQuery(
             [
-                'index' => $this->indexName,
-                'body'  => [
+                'index'     => $this->indexName,
+                'body'      => [
                     'query' => [
                         'match_all' => new stdClass(),
                     ],

--- a/src/Purger/HttpClientPurger.php
+++ b/src/Purger/HttpClientPurger.php
@@ -8,11 +8,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class HttpClientPurger implements PurgerInterface
 {
-    private $httpClient;
-
-    public function __construct(HttpClientInterface $httpClient)
+    public function __construct(private HttpClientInterface $httpClient)
     {
-        $this->httpClient = $httpClient;
     }
 
     public function purge(): void

--- a/src/Purger/NonTransactionalConnectionPurger.php
+++ b/src/Purger/NonTransactionalConnectionPurger.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Connection;
 
 final class NonTransactionalConnectionPurger implements PurgerInterface
 {
-    private $purger;
+    private PurgerInterface $purger;
 
     public function __construct(Connection $connection, array $excludedTables = [])
     {

--- a/src/Tools/ConnectionToolsTrait.php
+++ b/src/Tools/ConnectionToolsTrait.php
@@ -28,27 +28,19 @@ trait ConnectionToolsTrait
 
     protected function getDisableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
-        if ($driver instanceof AbstractMySQLDriver) {
-            return 'SET FOREIGN_KEY_CHECKS=0';
-        }
-
-        if ($driver instanceof AbstractSQLiteDriver) {
-            return 'PRAGMA foreign_keys = OFF';
-        }
-
-        return '';
+        return match (true) {
+            $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=0',
+            $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = OFF',
+            default                                 => ''
+        };
     }
 
     protected function getEnableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
-        if ($driver instanceof AbstractMySQLDriver) {
-            return 'SET FOREIGN_KEY_CHECKS=1';
-        }
-
-        if ($driver instanceof AbstractSQLiteDriver) {
-            return 'PRAGMA foreign_keys = ON';
-        }
-
-        return '';
+        return match (true) {
+            $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=1',
+            $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = ON',
+            default                                 => ''
+        };
     }
 }

--- a/src/Tools/HttpClient.php
+++ b/src/Tools/HttpClient.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Tools;
 
+use Generator;
 use ReflectionClass;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -12,7 +13,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class HttpClient extends MockHttpClient implements FixturesHttpClientInterface
 {
-    private $responses;
+    private ?array $responses = null;
 
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
@@ -59,7 +60,7 @@ final class HttpClient extends MockHttpClient implements FixturesHttpClientInter
 
     private function recreateResponseFactory(array $responses): void
     {
-        $responseFactory = (static function() use ($responses) {
+        $responseFactory = (static function() use ($responses): Generator {
             yield from $responses;
         })();
 

--- a/tests/Adapter/ElasticSearchArrayDirectoryFixtureTest.php
+++ b/tests/Adapter/ElasticSearchArrayDirectoryFixtureTest.php
@@ -10,79 +10,83 @@ use PHPUnit\Framework\TestCase;
 
 final class ElasticSearchArrayDirectoryFixtureTest extends TestCase
 {
+    private MockObject|Client $client;
+
     public function testLoad(): void
     {
-        /** @var Client|MockObject $client */
-        $client = $this->createMock(Client::class);
-
-        $client
-            ->expects($this->exactly(2))
-            ->method('bulk')
-            ->withConsecutive(
+        $bulk1 = [
+            'type' => '_doc',
+            'body' => [
                 [
-                    [
-                        'type' => '_doc',
-                        'body' => [
-                            [
-                                'index' => [
-                                    '_index' => 'my_index',
-                                    '_id'    => 1,
-                                    '_type'  => '_doc',
-                                ],
-                            ],
-                            [
-                                'id'         => 1,
-                                'name'       => 'Document 1',
-                                'attributes' => [
-                                    'attrib_1' => 1,
-                                    'attrib_2' => 'active',
-                                    'attrib_3' => true,
-                                ],
-                            ],
-                            [
-                                'index' => [
-                                    '_index' => 'my_index',
-                                    '_id'    => 2,
-                                    '_type'  => '_doc',
-                                ],
-                            ],
-                            [
-                                'id'         => 2,
-                                'name'       => 'Document 2',
-                                'attributes' => [
-                                    'attrib_1' => 2,
-                                    'attrib_2' => 'inactive',
-                                    'attrib_3' => false,
-                                ],
-                            ],
-                        ],
+                    'index' => [
+                        '_index' => 'my_index',
+                        '_id'    => 1,
+                        '_type'  => '_doc',
                     ],
                 ],
                 [
-                    [
-                        'type' => '_doc',
-                        'body' => [
-                            [
-                                'index' => [
-                                    '_index' => 'my_index',
-                                    '_id'    => 3,
-                                    '_type'  => '_doc',
-                                ],
-                            ],
-                            [
-                                'id'         => 3,
-                                'name'       => 'Document 3',
-                                'attributes' => [
-                                    'attrib_1' => 3,
-                                    'attrib_2' => 'inactive',
-                                    'attrib_3' => false,
-                                ],
-                            ],
-                        ],
+                    'id'         => 1,
+                    'name'       => 'Document 1',
+                    'attributes' => [
+                        'attrib_1' => 1,
+                        'attrib_2' => 'active',
+                        'attrib_3' => true,
                     ],
-                ]
+                ],
+                [
+                    'index' => [
+                        '_index' => 'my_index',
+                        '_id'    => 2,
+                        '_type'  => '_doc',
+                    ],
+                ],
+                [
+                    'id'         => 2,
+                    'name'       => 'Document 2',
+                    'attributes' => [
+                        'attrib_1' => 2,
+                        'attrib_2' => 'inactive',
+                        'attrib_3' => false,
+                    ],
+                ],
+            ],
+        ];
+        $bulk2 = [
+            'type' => '_doc',
+            'body' => [
+                [
+                    'index' => [
+                        '_index' => 'my_index',
+                        '_id'    => 3,
+                        '_type'  => '_doc',
+                    ],
+                ],
+                [
+                    'id'         => 3,
+                    'name'       => 'Document 3',
+                    'attributes' => [
+                        'attrib_1' => 3,
+                        'attrib_2' => 'inactive',
+                        'attrib_3' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->client
+            ->expects($this->exactly(2))
+            ->method('bulk')
+            ->with(
+                $this->callback(
+                    fn (array $bulk): bool => ($bulk == $bulk1 || $bulk == $bulk2)
+                )
             );
 
-        (new ElasticSearchArrayDirectoryFixture1())->load($client, 'my_index');
+        (new ElasticSearchArrayDirectoryFixture1())->load($this->client, 'my_index');
+    }
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(Client::class);
     }
 }

--- a/tests/Adapter/ElasticSearchFixtureTest.php
+++ b/tests/Adapter/ElasticSearchFixtureTest.php
@@ -10,12 +10,11 @@ use PHPUnit\Framework\TestCase;
 
 final class ElasticSearchFixtureTest extends TestCase
 {
+    private MockObject|Client $client;
+
     public function testLoad(): void
     {
-        /** @var Client|MockObject $client */
-        $client = $this->createMock(Client::class);
-
-        $client
+        $this->client
             ->expects($this->once())
             ->method('bulk')
             ->with([
@@ -54,6 +53,11 @@ final class ElasticSearchFixtureTest extends TestCase
                 ],
             ]);
 
-        (new ElasticSearchFixture3())->load($client, 'my_index');
+        (new ElasticSearchFixture3())->load($this->client, 'my_index');
+    }
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(Client::class);
     }
 }

--- a/tests/Adapter/ElasticSearchJsonDirectoryFixtureTest.php
+++ b/tests/Adapter/ElasticSearchJsonDirectoryFixtureTest.php
@@ -12,72 +12,71 @@ use PHPUnit\Framework\TestCase;
 
 final class ElasticSearchJsonDirectoryFixtureTest extends TestCase
 {
-    /** @var Client|MockObject */
-    private $client;
+    private MockObject|Client $client;
 
     public function testLoad(): void
     {
-        $this->client
-            ->expects($this->exactly(2))
-            ->method('bulk')
-            ->withConsecutive(
+        $bulk1 = [
+            'body' => [
                 [
-                    [
-                        'body' => [
-                            [
-                                'index' => [
-                                    '_index' => 'my_index',
-                                    '_id'    => '17e05f79-2c6e-4a71-bacf-afc8fd8e5f73',
-                                ],
-                            ],
-                            [
-                                'uuid'       => '17e05f79-2c6e-4a71-bacf-afc8fd8e5f73',
-                                'name'       => 'Document 1',
-                                'attributes' => [
-                                    'attrib_1' => 1,
-                                    'attrib_2' => 'active',
-                                    'attrib_3' => true,
-                                ],
-                            ],
-                            [
-                                'index' => [
-                                    '_index' => 'my_index',
-                                    '_id'    => 'e3d49639-a8f7-4b21-96d7-e4a22e87e1da',
-                                ],
-                            ],
-                            [
-                                'uuid'       => 'e3d49639-a8f7-4b21-96d7-e4a22e87e1da',
-                                'name'       => 'Document 2',
-                                'attributes' => [
-                                    'attrib_1' => 2,
-                                    'attrib_2' => 'inactive',
-                                    'attrib_3' => false,
-                                ],
-                            ],
-                        ],
+                    'index' => [
+                        '_index' => 'my_index',
+                        '_id'    => '17e05f79-2c6e-4a71-bacf-afc8fd8e5f73',
                     ],
                 ],
                 [
-                    [
-                        'body' => [
-                            [
-                                'index' => [
-                                    '_index' => 'my_index',
-                                    '_id'    => 'd1cd10a0-7023-434c-8cd3-0196e1d34c2f',
-                                ],
-                            ],
-                            [
-                                'uuid'       => 'd1cd10a0-7023-434c-8cd3-0196e1d34c2f',
-                                'name'       => 'Document 3',
-                                'attributes' => [
-                                    'attrib_1' => 3,
-                                    'attrib_2' => 'inactive',
-                                    'attrib_3' => false,
-                                ],
-                            ],
-                        ],
+                    'uuid'       => '17e05f79-2c6e-4a71-bacf-afc8fd8e5f73',
+                    'name'       => 'Document 1',
+                    'attributes' => [
+                        'attrib_1' => 1,
+                        'attrib_2' => 'active',
+                        'attrib_3' => true,
                     ],
-                ]
+                ],
+                [
+                    'index' => [
+                        '_index' => 'my_index',
+                        '_id'    => 'e3d49639-a8f7-4b21-96d7-e4a22e87e1da',
+                    ],
+                ],
+                [
+                    'uuid'       => 'e3d49639-a8f7-4b21-96d7-e4a22e87e1da',
+                    'name'       => 'Document 2',
+                    'attributes' => [
+                        'attrib_1' => 2,
+                        'attrib_2' => 'inactive',
+                        'attrib_3' => false,
+                    ],
+                ],
+            ],
+        ];
+        $bulk2 = [
+            'body' => [
+                [
+                    'index' => [
+                        '_index' => 'my_index',
+                        '_id'    => 'd1cd10a0-7023-434c-8cd3-0196e1d34c2f',
+                    ],
+                ],
+                [
+                    'uuid'       => 'd1cd10a0-7023-434c-8cd3-0196e1d34c2f',
+                    'name'       => 'Document 3',
+                    'attributes' => [
+                        'attrib_1' => 3,
+                        'attrib_2' => 'inactive',
+                        'attrib_3' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->client
+            ->expects($this->exactly(2))
+            ->method('bulk')
+            ->with(
+                $this->callback(
+                    fn (array $bulk): bool => ($bulk == $bulk1 || $bulk == $bulk2)
+                )
             );
 
         (new ElasticSearchJsonDirectoryFixture1())->load($this->client, 'my_index');

--- a/tests/Adapter/HttpClientArrayDirectoryFixtureTest.php
+++ b/tests/Adapter/HttpClientArrayDirectoryFixtureTest.php
@@ -5,11 +5,12 @@ namespace Kununu\DataFixtures\Tests\Adapter;
 
 use Kununu\DataFixtures\Tests\TestFixtures\HttpClientArrayDirectoryFixture1;
 use Kununu\DataFixtures\Tools\FixturesHttpClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class HttpClientArrayDirectoryFixtureTest extends TestCase
 {
-    private $httpClient;
+    private MockObject|FixturesHttpClientInterface $httpClient;
 
     public function testLoad(): void
     {

--- a/tests/Adapter/HttpClientPhpArrayFixtureTest.php
+++ b/tests/Adapter/HttpClientPhpArrayFixtureTest.php
@@ -9,11 +9,12 @@ use Kununu\DataFixtures\Tests\TestFixtures\HttpClientFixture2;
 use Kununu\DataFixtures\Tests\TestFixtures\InvalidHttpClientFixture;
 use Kununu\DataFixtures\Tests\Utils\FakeHttpClientInterface;
 use Kununu\DataFixtures\Tools\FixturesHttpClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class HttpClientPhpArrayFixtureTest extends TestCase
 {
-    private $httpClient;
+    private MockObject|FixturesHttpClientInterface $httpClient;
 
     public function testLoad(): void
     {

--- a/tests/Executor/AbstractExecutorTestCase.php
+++ b/tests/Executor/AbstractExecutorTestCase.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Tests\Executor;
+
+use Kununu\DataFixtures\Executor\ExecutorInterface;
+use Kununu\DataFixtures\Purger\PurgerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractExecutorTestCase extends TestCase
+{
+    protected MockObject|PurgerInterface $purger;
+    protected ExecutorInterface $executor;
+
+    abstract protected function getExecutor(): ExecutorInterface;
+
+    protected function setUp(): void
+    {
+        $this->purger = $this->createMock(PurgerInterface::class);
+        $this->executor = $this->getExecutor();
+    }
+}

--- a/tests/Executor/ElasticSearchExecutorTest.php
+++ b/tests/Executor/ElasticSearchExecutorTest.php
@@ -7,19 +7,14 @@ use Elasticsearch\Client;
 use Elasticsearch\Namespaces\IndicesNamespace;
 use Kununu\DataFixtures\Adapter\ElasticSearchFixtureInterface;
 use Kununu\DataFixtures\Executor\ElasticSearchExecutor;
-use Kununu\DataFixtures\Purger\PurgerInterface;
+use Kununu\DataFixtures\Executor\ExecutorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
-final class ElasticSearchExecutorTest extends TestCase
+final class ElasticSearchExecutorTest extends AbstractExecutorTestCase
 {
     private const INDEX_NAME = 'my_index';
 
-    /** @var Client|MockObject */
-    private $client;
-
-    /** @var PurgerInterface|MockObject */
-    private $purger;
+    private MockObject|Client $client;
 
     public function testThatDoesNotPurgesWhenAppendIsEnabled(): void
     {
@@ -27,9 +22,7 @@ final class ElasticSearchExecutorTest extends TestCase
             ->expects($this->never())
             ->method('purge');
 
-        $executor = new ElasticSearchExecutor($this->client, self::INDEX_NAME, $this->purger);
-
-        $executor->execute([], true);
+        $this->executor->execute([], true);
     }
 
     public function testThatPurgesWhenAppendIsDisabled(): void
@@ -38,9 +31,7 @@ final class ElasticSearchExecutorTest extends TestCase
             ->expects($this->once())
             ->method('purge');
 
-        $executor = new ElasticSearchExecutor($this->client, self::INDEX_NAME, $this->purger);
-
-        $executor->execute([]);
+        $this->executor->execute([]);
     }
 
     public function testThatFixturesAreLoaded(): void
@@ -68,16 +59,18 @@ final class ElasticSearchExecutorTest extends TestCase
             ->method('indices')
             ->willReturn($indices);
 
-        $executor = new ElasticSearchExecutor($this->client, self::INDEX_NAME, $this->purger);
-
-        $executor->execute([$fixture1, $fixture2]);
+        $this->executor->execute([$fixture1, $fixture2]);
     }
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->client = $this->createMock(Client::class);
-        $this->purger = $this->createMock(PurgerInterface::class);
+
+        parent::setUp();
+    }
+
+    protected function getExecutor(): ExecutorInterface
+    {
+        return new ElasticSearchExecutor($this->client, self::INDEX_NAME, $this->purger);
     }
 }

--- a/tests/Executor/HttpClientExecutorTest.php
+++ b/tests/Executor/HttpClientExecutorTest.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 namespace Kununu\DataFixtures\Tests\Executor;
 
 use Kununu\DataFixtures\Adapter\HttpClientFixtureInterface;
+use Kununu\DataFixtures\Executor\ExecutorInterface;
 use Kununu\DataFixtures\Executor\HttpClientExecutor;
-use Kununu\DataFixtures\Purger\PurgerInterface;
 use Kununu\DataFixtures\Tools\FixturesHttpClientInterface;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
-final class HttpClientExecutorTest extends TestCase
+final class HttpClientExecutorTest extends AbstractExecutorTestCase
 {
-    private $httpClient;
-    private $purger;
-    private $executor;
+    private MockObject|FixturesHttpClientInterface $httpClient;
 
     public function testThatDoesNotPurgesWhenAppendIsEnabled(): void
     {
@@ -53,7 +51,11 @@ final class HttpClientExecutorTest extends TestCase
     protected function setUp(): void
     {
         $this->httpClient = $this->createMock(FixturesHttpClientInterface::class);
-        $this->purger = $this->createMock(PurgerInterface::class);
-        $this->executor = new HttpClientExecutor($this->httpClient, $this->purger);
+        parent::setUp();
+    }
+
+    protected function getExecutor(): ExecutorInterface
+    {
+        return new HttpClientExecutor($this->httpClient, $this->purger);
     }
 }

--- a/tests/Loader/AbstractLoaderTestCase.php
+++ b/tests/Loader/AbstractLoaderTestCase.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Tests\Loader;
+
+use InvalidArgumentException;
+use Kununu\DataFixtures\FixtureInterface;
+use Kununu\DataFixtures\Loader\LoaderInterface;
+use Kununu\DataFixtures\Tests\TestFixtures\NotAFixture;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractLoaderTestCase extends TestCase
+{
+    protected MockObject|LoaderInterface $loader;
+    private array $fixtureClasses = [];
+    private array $fixtureFiles = [];
+
+    public function testGetFixture(): void
+    {
+        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/' . $this->fixtureFiles[0]);
+
+        $fixture = $this->loader->getFixture($fixtureClass = $this->fixtureClasses[0]);
+
+        $this->assertInstanceOf($fixtureClass, $fixture);
+    }
+
+    public function testGetFixtureThrowsExceptionWhenFixtureDoesNotExists(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->loader->getFixture($this->fixtureClasses[0]);
+    }
+
+    public function testLoadFromClassName(): void
+    {
+        $this->loader->addFixture($this->getNamedFixtureMock('Mock1'));
+        $this->loader->addFixture($this->getNamedFixtureMock('Mock2'));
+
+        $this->assertCount(2, $this->loader->getFixtures());
+
+        $this->loader->loadFromClassName(NotAFixture::class);
+        $this->assertCount(2, $this->loader->getFixtures());
+
+        $count = 2;
+        foreach ($this->fixtureClasses as $fixtureClass) {
+            $this->loader->loadFromClassName($fixtureClass);
+            $count++;
+            $this->assertCount($count, $this->loader->getFixtures());
+        }
+    }
+
+    public function testLoadFromDirectory(): void
+    {
+        $this->loader->addFixture($this->getNamedFixtureMock('Mock1'));
+        $this->loader->addFixture($this->getNamedFixtureMock('Mock2'));
+
+        $this->assertCount(2, $this->loader->getFixtures());
+
+        $this->loader->loadFromDirectory(__DIR__ . '/../TestFixtures/');
+        $this->assertCount($this->expectedNumberOfFixturesFromDirectory(), $this->loader->getFixtures());
+
+        $this->loader->clearFixtures();
+        $this->assertEmpty($this->loader->getFixtures());
+    }
+
+    public function testLoadFromDirectoryThrowsExceptionIfNotDirectory(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->loader->loadFromDirectory(__DIR__ . '/../NotFoundDirectory/');
+    }
+
+    public function testLoadFromFile(): void
+    {
+        $this->loader->addFixture($this->getNamedFixtureMock('Mock1'));
+        $this->loader->addFixture($this->getNamedFixtureMock('Mock2'));
+
+        $this->assertCount(2, $this->loader->getFixtures());
+
+        $this->initializeLoadFromFileFixtures();
+
+        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/NotAFixture.php');
+        $this->assertCount(2, $this->loader->getFixtures());
+
+        $count = 2;
+        foreach ($this->fixtureFiles as $fixtureFile) {
+            $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/' . $fixtureFile);
+            $count++;
+            $this->assertCount($count, $this->loader->getFixtures());
+        }
+
+        $this->performExtraLoadFromFileFixturesAssertions();
+    }
+
+    public function testLoadFromFileThrowsExceptionForInvalidFile(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->loader->loadFromFile(__DIR__ . '/../NotFoundDirectory/ThisDoesNotExists.php');
+    }
+
+    abstract protected function getLoader(): LoaderInterface;
+
+    abstract protected function getFixtureInterfaceName(): string;
+
+    abstract protected function getFixtureClasses(): array;
+
+    abstract protected function expectedNumberOfFixturesFromDirectory(): int;
+
+    protected function setUp(): void
+    {
+        $this->loader = $this->getLoader();
+        $this->fixtureClasses = array_keys($this->getFixtureClasses());
+        $this->fixtureFiles = array_values($this->getFixtureClasses());
+    }
+
+    protected function initializeLoadFromFileFixtures(): void
+    {
+    }
+
+    protected function performExtraLoadFromFileFixturesAssertions(): void
+    {
+    }
+
+    protected function getNamedFixtureMock(string $name): MockObject|FixtureInterface
+    {
+        return $this->getMockBuilder($this->getFixtureInterfaceName())
+            ->setMockClassName($name)
+            ->getMock();
+    }
+}

--- a/tests/Loader/CachePoolFixturesLoaderTest.php
+++ b/tests/Loader/CachePoolFixturesLoaderTest.php
@@ -3,55 +3,39 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Tests\Loader;
 
-use InvalidArgumentException;
 use Kununu\DataFixtures\Adapter\CachePoolFixtureInterface;
 use Kununu\DataFixtures\Loader\CachePoolFixturesLoader;
+use Kununu\DataFixtures\Loader\LoaderInterface;
 use Kununu\DataFixtures\Tests\TestFixtures\CachePoolFixture1;
 use Kununu\DataFixtures\Tests\TestFixtures\CachePoolFixture2;
-use Kununu\DataFixtures\Tests\TestFixtures\NotAFixture;
-use PHPUnit\Framework\TestCase;
 
-final class CachePoolFixturesLoaderTest extends TestCase
+final class CachePoolFixturesLoaderTest extends AbstractLoaderTestCase
 {
-    /** @var CachePoolFixturesLoader */
-    private $loader;
-
-    public function testLoadFromDirectory(): void
+    protected function getLoader(): LoaderInterface
     {
-        $this->loader->addFixture(
-            $this->getMockBuilder(CachePoolFixtureInterface::class)->setMockClassName('Mock1')->getMock()
-        );
-        $this->loader->addFixture(
-            $this->getMockBuilder(CachePoolFixtureInterface::class)->setMockClassName('Mock2')->getMock()
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../TestFixtures/');
-        $this->assertCount(4, $this->loader->getFixtures());
-
-        $this->loader->clearFixtures();
-        $this->assertEmpty($this->loader->getFixtures());
+        return new CachePoolFixturesLoader();
     }
 
-    public function testLoadFromDirectoryThrowsExceptionIfNotDirectory(): void
+    protected function getFixtureInterfaceName(): string
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../NotFoundDirectory/');
+        return CachePoolFixtureInterface::class;
     }
 
-    public function testLoadFromFile(): void
+    protected function expectedNumberOfFixturesFromDirectory(): int
     {
-        $this->loader->addFixture(
-            $this->getMockBuilder(CachePoolFixtureInterface::class)->setMockClassName('Mock1')->getMock()
-        );
-        $this->loader->addFixture(
-            $this->getMockBuilder(CachePoolFixtureInterface::class)->setMockClassName('Mock2')->getMock()
-        );
+        return 4;
+    }
 
-        $this->assertCount(2, $this->loader->getFixtures());
+    protected function getFixtureClasses(): array
+    {
+        return [
+            CachePoolFixture1::class => 'CachePoolFixture1.php',
+            CachePoolFixture2::class => 'CachePoolFixture2.php',
+        ];
+    }
 
+    protected function initializeLoadFromFileFixtures(): void
+    {
         $this->loader->registerInitializableFixture(
             CachePoolFixture1::class,
             2020,
@@ -61,73 +45,25 @@ final class CachePoolFixturesLoaderTest extends TestCase
                 'value' => 1.35,
             ]
         );
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/CachePoolFixture1.php');
+    }
+
+    protected function performExtraLoadFromFileFixturesAssertions(): void
+    {
         $loadedFixtures = $this->loader->getFixtures();
-        $this->assertCount(3, $loadedFixtures);
+
         $this->assertArrayHasKey(CachePoolFixture1::class, $loadedFixtures);
-        /** @var CachePoolFixture1 $cachePoolFixture1 */
+
         $cachePoolFixture1 = $loadedFixtures[CachePoolFixture1::class];
+
         $this->assertInstanceOf(CachePoolFixture1::class, $cachePoolFixture1);
-        $this->assertEquals($cachePoolFixture1->arg1(), 2020);
+        $this->assertEquals(2020, $cachePoolFixture1->arg1());
         $this->assertEquals(
-            $cachePoolFixture1->arg2(),
             [
                 'id'    => 1,
                 'name'  => 'Test Subject',
                 'value' => 1.35,
-            ]
+            ],
+            $cachePoolFixture1->arg2()
         );
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/NotAFixture.php');
-        $this->assertCount(3, $this->loader->getFixtures());
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/CachePoolFixture2.php');
-        $this->assertCount(4, $this->loader->getFixtures());
-    }
-
-    public function testLoadFromFileThrowsExceptionForInvalidFile(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromFile(__DIR__ . '/../NotFoundDirectory/CachePoolFixture1.php');
-    }
-
-    public function testLoadFromClassName(): void
-    {
-        $this->loader->addFixture(
-            $this->getMockBuilder(CachePoolFixtureInterface::class)->setMockClassName('Mock1')->getMock()
-        );
-        $this->loader->addFixture(
-            $this->getMockBuilder(CachePoolFixtureInterface::class)->setMockClassName('Mock2')->getMock()
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(CachePoolFixture1::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-        $this->loader->loadFromClassName(NotAFixture::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-        $this->loader->loadFromClassName(CachePoolFixture2::class);
-        $this->assertCount(4, $this->loader->getFixtures());
-    }
-
-    public function testGetFixture(): void
-    {
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/CachePoolFixture1.php');
-
-        $fixture = $this->loader->getFixture(CachePoolFixture1::class);
-
-        $this->assertInstanceOf(CachePoolFixture1::class, $fixture);
-    }
-
-    public function testGetFixtureThrowsExceptionWhenFixtureDoesNotExists(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->getFixture(CachePoolFixture1::class);
-    }
-
-    protected function setUp(): void
-    {
-        $this->loader = new CachePoolFixturesLoader();
     }
 }

--- a/tests/Loader/ConnectionFixturesLoaderTest.php
+++ b/tests/Loader/ConnectionFixturesLoaderTest.php
@@ -3,120 +3,36 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Tests\Loader;
 
-use InvalidArgumentException;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 use Kununu\DataFixtures\Loader\ConnectionFixturesLoader;
+use Kununu\DataFixtures\Loader\LoaderInterface;
 use Kununu\DataFixtures\Tests\TestFixtures\ConnectionFixture1;
 use Kununu\DataFixtures\Tests\TestFixtures\ConnectionFixture2;
 use Kununu\DataFixtures\Tests\TestFixtures\ConnectionFixture3;
-use Kununu\DataFixtures\Tests\TestFixtures\NotAFixture;
-use PHPUnit\Framework\TestCase;
 
-final class ConnectionFixturesLoaderTest extends TestCase
+final class ConnectionFixturesLoaderTest extends AbstractLoaderTestCase
 {
-    /** @var ConnectionFixturesLoader */
-    private $loader;
-
-    public function testLoadFromDirectory(): void
+    protected function getLoader(): LoaderInterface
     {
-        $this->loader->addFixture(
-            $this->getMockBuilder(ConnectionFixtureInterface::class)->setMockClassName('Mock1')->getMock()
-        );
-        $this->loader->addFixture(
-            $this->getMockBuilder(ConnectionFixtureInterface::class)->setMockClassName('Mock2')->getMock()
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../TestFixtures/');
-        $this->assertCount(8, $this->loader->getFixtures());
-
-        $this->loader->clearFixtures();
-        $this->assertEmpty($this->loader->getFixtures());
+        return new ConnectionFixturesLoader();
     }
 
-    public function testLoadFromDirectoryThrowsExceptionIfNotDirectory(): void
+    protected function getFixtureInterfaceName(): string
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../NotFoundDirectory/');
+        return ConnectionFixtureInterface::class;
     }
 
-    public function testLoadFromFile(): void
+    protected function expectedNumberOfFixturesFromDirectory(): int
     {
-        $this->loader->addFixture(
-            $this->getMockBuilder(ConnectionFixtureInterface::class)->setMockClassName('Mock1')->getMock()
-        );
-        $this->loader->addFixture(
-            $this->getMockBuilder(ConnectionFixtureInterface::class)->setMockClassName('Mock2')->getMock()
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/ConnectionFixture1.php');
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/NotAFixture.php');
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/ConnectionFixture2.php');
-        $this->assertCount(4, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/ConnectionFixture3.php');
-        $this->assertCount(5, $this->loader->getFixtures());
+        return 8;
     }
 
-    public function testLoadFromFileThrowsExceptionForInvalidFile(): void
+    protected function getFixtureClasses(): array
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromFile(__DIR__ . '/../NotFoundDirectory/CachePoolFixture1.php');
-    }
-
-    public function testLoadFromClassName(): void
-    {
-        $this->loader->addFixture(
-            $this->getMockBuilder(ConnectionFixtureInterface::class)->setMockClassName('Mock1')->getMock()
-        );
-        $this->loader->addFixture(
-            $this->getMockBuilder(ConnectionFixtureInterface::class)->setMockClassName('Mock2')->getMock()
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(ConnectionFixture1::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(NotAFixture::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(ConnectionFixture2::class);
-        $this->assertCount(4, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(ConnectionFixture3::class);
-        $this->assertCount(5, $this->loader->getFixtures());
-    }
-
-    public function testGetFixture(): void
-    {
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/ConnectionFixture1.php');
-
-        $fixture = $this->loader->getFixture(ConnectionFixture1::class);
-
-        $this->assertInstanceOf(ConnectionFixture1::class, $fixture);
-    }
-
-    public function testGetFixtureThrowsExceptionWhenFixtureDoesNotExists(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->getFixture(ConnectionFixture1::class);
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->loader = new ConnectionFixturesLoader();
+        return [
+            ConnectionFixture1::class => 'ConnectionFixture1.php',
+            ConnectionFixture2::class => 'ConnectionFixture2.php',
+            ConnectionFixture3::class => 'ConnectionFixture3.php',
+        ];
     }
 }

--- a/tests/Loader/ElasticSearchFixturesLoaderTest.php
+++ b/tests/Loader/ElasticSearchFixturesLoaderTest.php
@@ -3,122 +3,34 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Tests\Loader;
 
-use InvalidArgumentException;
 use Kununu\DataFixtures\Adapter\ElasticSearchFixtureInterface;
 use Kununu\DataFixtures\Loader\ElasticSearchFixturesLoader;
+use Kununu\DataFixtures\Loader\LoaderInterface;
 use Kununu\DataFixtures\Tests\TestFixtures\ElasticSearchFixture1;
 use Kununu\DataFixtures\Tests\TestFixtures\ElasticSearchFixture2;
-use Kununu\DataFixtures\Tests\TestFixtures\NotAFixture;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
-final class ElasticSearchFixturesLoaderTest extends TestCase
+final class ElasticSearchFixturesLoaderTest extends AbstractLoaderTestCase
 {
-    /** @var ElasticSearchFixturesLoader */
-    private $loader;
-
-    public function testLoadFromDirectory(): void
+    protected function getLoader(): LoaderInterface
     {
-        $this->loader->addFixture(
-            $this->getNamedElasticSearchFixtureMock('Mock1')
-        );
-        $this->loader->addFixture(
-            $this->getNamedElasticSearchFixtureMock('Mock2')
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../TestFixtures/');
-        $this->assertCount(8, $this->loader->getFixtures());
-
-        $this->loader->clearFixtures();
-        $this->assertEmpty($this->loader->getFixtures());
+        return new ElasticSearchFixturesLoader();
     }
 
-    public function testLoadFromDirectoryThrowsExceptionIfNotDirectory(): void
+    protected function getFixtureInterfaceName(): string
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../NotFoundDirectory/');
+        return ElasticSearchFixtureInterface::class;
     }
 
-    public function testLoadFromFile(): void
+    protected function expectedNumberOfFixturesFromDirectory(): int
     {
-        $this->loader->addFixture(
-            $this->getNamedElasticSearchFixtureMock('Mock1')
-        );
-        $this->loader->addFixture(
-            $this->getNamedElasticSearchFixtureMock('Mock2')
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/ElasticSearchFixture1.php');
-        $this->assertCount(3, $this->loader->getFixtures());
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/NotAFixture.php');
-        $this->assertCount(3, $this->loader->getFixtures());
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/ElasticSearchFixture2.php');
-        $this->assertCount(4, $this->loader->getFixtures());
+        return 8;
     }
 
-    public function testLoadFromFileThrowsExceptionForInvalidFile(): void
+    protected function getFixtureClasses(): array
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromFile(__DIR__ . '/../NotFoundDirectory/ElasticSearchFixture1.php');
-    }
-
-    public function testLoadFromClassName(): void
-    {
-        $this->loader->addFixture(
-            $this->getNamedElasticSearchFixtureMock('Mock1')
-        );
-        $this->loader->addFixture(
-            $this->getNamedElasticSearchFixtureMock('Mock2')
-        );
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(ElasticSearchFixture1::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-        $this->loader->loadFromClassName(NotAFixture::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-        $this->loader->loadFromClassName(ElasticSearchFixture2::class);
-        $this->assertCount(4, $this->loader->getFixtures());
-    }
-
-    public function testGetFixture(): void
-    {
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/ElasticSearchFixture1.php');
-
-        $fixture = $this->loader->getFixture(ElasticSearchFixture1::class);
-
-        $this->assertInstanceOf(ElasticSearchFixture1::class, $fixture);
-    }
-
-    public function testGetFixtureThrowsExceptionWhenFixtureDoesNotExists(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->getFixture(ElasticSearchFixture1::class);
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->loader = new ElasticSearchFixturesLoader();
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return ElasticSearchFixtureInterface|MockObject
-     */
-    private function getNamedElasticSearchFixtureMock(string $name)
-    {
-        return $this->getMockBuilder(ElasticSearchFixtureInterface::class)
-            ->setMockClassName($name)
-            ->getMock();
+        return [
+            ElasticSearchFixture1::class => 'ElasticSearchFixture1.php',
+            ElasticSearchFixture2::class => 'ElasticSearchFixture2.php',
+        ];
     }
 }

--- a/tests/Loader/HttpClientFixturesLoaderTest.php
+++ b/tests/Loader/HttpClientFixturesLoaderTest.php
@@ -3,111 +3,34 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Tests\Loader;
 
-use InvalidArgumentException;
 use Kununu\DataFixtures\Adapter\HttpClientFixtureInterface;
 use Kununu\DataFixtures\Loader\HttpClientFixturesLoader;
+use Kununu\DataFixtures\Loader\LoaderInterface;
 use Kununu\DataFixtures\Tests\TestFixtures\HttpClientFixture1;
 use Kununu\DataFixtures\Tests\TestFixtures\HttpClientFixture2;
-use Kununu\DataFixtures\Tests\TestFixtures\NotAFixture;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
-final class HttpClientFixturesLoaderTest extends TestCase
+final class HttpClientFixturesLoaderTest extends AbstractLoaderTestCase
 {
-    private $loader;
-
-    public function testLoadFromDirectory(): void
+    protected function getLoader(): LoaderInterface
     {
-        $this->loader->addFixture($this->getNamedHttpClientFixtureMock('Mock1'));
-        $this->loader->addFixture($this->getNamedHttpClientFixtureMock('Mock2'));
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../TestFixtures/');
-        $this->assertCount(6, $this->loader->getFixtures());
-
-        $this->loader->clearFixtures();
-        $this->assertEmpty($this->loader->getFixtures());
+        return new HttpClientFixturesLoader();
     }
 
-    public function testLoadFromDirectoryThrowsExceptionIfNotDirectory(): void
+    protected function getFixtureInterfaceName(): string
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromDirectory(__DIR__ . '/../NotFoundDirectory/');
+        return HttpClientFixtureInterface::class;
     }
 
-    public function testLoadFromFile(): void
+    protected function getFixtureClasses(): array
     {
-        $this->loader->addFixture($this->getNamedHttpClientFixtureMock('Mock1'));
-        $this->loader->addFixture($this->getNamedHttpClientFixtureMock('Mock2'));
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/HttpClientFixture1.php');
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/NotAFixture.php');
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/HttpClientFixture2.php');
-        $this->assertCount(4, $this->loader->getFixtures());
+        return [
+            HttpClientFixture1::class => 'HttpClientFixture1.php',
+            HttpClientFixture2::class => 'HttpClientFixture2.php',
+        ];
     }
 
-    public function testLoadFromFileThrowsExceptionForInvalidFile(): void
+    protected function expectedNumberOfFixturesFromDirectory(): int
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->loadFromFile(__DIR__ . '/../NotFoundDirectory/HttpClientFixture1.php');
-    }
-
-    public function testLoadFromClassName(): void
-    {
-        $this->loader->addFixture($this->getNamedHttpClientFixtureMock('Mock1'));
-        $this->loader->addFixture($this->getNamedHttpClientFixtureMock('Mock2'));
-
-        $this->assertCount(2, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(HttpClientFixture1::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(NotAFixture::class);
-        $this->assertCount(3, $this->loader->getFixtures());
-
-        $this->loader->loadFromClassName(HttpClientFixture2::class);
-        $this->assertCount(4, $this->loader->getFixtures());
-    }
-
-    public function testGetFixture(): void
-    {
-        $this->loader->loadFromFile(__DIR__ . '/../TestFixtures/HttpClientFixture1.php');
-
-        $fixture = $this->loader->getFixture(HttpClientFixture1::class);
-
-        $this->assertInstanceOf(HttpClientFixture1::class, $fixture);
-    }
-
-    public function testGetFixtureThrowsExceptionWhenFixtureDoesNotExists(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->loader->getFixture(HttpClientFixture1::class);
-    }
-
-    protected function setUp(): void
-    {
-        $this->loader = new HttpClientFixturesLoader();
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return HttpClientFixtureInterface|MockObject
-     */
-    private function getNamedHttpClientFixtureMock(string $name)
-    {
-        return $this->getMockBuilder(HttpClientFixtureInterface::class)
-            ->setMockClassName($name)
-            ->getMock();
+        return 6;
     }
 }

--- a/tests/Purger/AbstractPurgerTestCase.php
+++ b/tests/Purger/AbstractPurgerTestCase.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\DataFixtures\Tests\Purger;
+
+use Kununu\DataFixtures\Purger\PurgerInterface;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractPurgerTestCase extends TestCase
+{
+    protected PurgerInterface $purger;
+
+    abstract protected function getPurger(): PurgerInterface;
+
+    protected function setUp(): void
+    {
+        $this->purger = $this->getPurger();
+    }
+}

--- a/tests/Purger/CachePoolPurgerTest.php
+++ b/tests/Purger/CachePoolPurgerTest.php
@@ -5,14 +5,13 @@ namespace Kununu\DataFixtures\Tests\Purger;
 
 use Kununu\DataFixtures\Exception\PurgeFailedException;
 use Kununu\DataFixtures\Purger\CachePoolPurger;
+use Kununu\DataFixtures\Purger\PurgerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
-final class CachePoolPurgerTest extends TestCase
+final class CachePoolPurgerTest extends AbstractPurgerTestCase
 {
-    /** @var MockObject|CacheItemPoolInterface */
-    private $cache;
+    private MockObject|CacheItemPoolInterface $cache;
 
     public function testThatCacheItemPoolIsPurged(): void
     {
@@ -21,8 +20,7 @@ final class CachePoolPurgerTest extends TestCase
             ->method('clear')
             ->willReturn(true);
 
-        $purger = new CachePoolPurger($this->cache);
-        $purger->purge();
+        $this->purger->purge();
     }
 
     public function testThatWhenCacheItemPoolFailsToPurgeThenAnExceptionIsThrown(): void
@@ -34,14 +32,17 @@ final class CachePoolPurgerTest extends TestCase
             ->method('clear')
             ->willReturn(false);
 
-        $purger = new CachePoolPurger($this->cache);
-        $purger->purge();
+        $this->purger->purge();
     }
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->cache = $this->createMock(CacheItemPoolInterface::class);
+        parent::setUp();
+    }
+
+    protected function getPurger(): PurgerInterface
+    {
+        return new CachePoolPurger($this->cache);
     }
 }

--- a/tests/Purger/ConnectionPurgerTest.php
+++ b/tests/Purger/ConnectionPurgerTest.php
@@ -3,18 +3,15 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Tests\Purger;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Exception;
 use Kununu\DataFixtures\Exception\InvalidConnectionPurgeModeException;
 use Kununu\DataFixtures\Purger\ConnectionPurger;
-use PHPUnit\Framework\MockObject\MockObject;
 
 final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 {
     public function testThatPurgerIsTransactionalAndCommits(): void
     {
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock();
 
         $connection
@@ -46,7 +43,6 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
     {
         $this->expectException(Exception::class);
 
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock();
 
         $connection
@@ -81,7 +77,6 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 
     public function testThatWhenNoTablesAreProvidedNothingIsPurged(): void
     {
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock(true, []);
 
         $connection
@@ -94,13 +89,14 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 
     public function testThatExcludedTablesAreNotPurged(): void
     {
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock();
 
         $connection
             ->expects($this->exactly(4))
             ->method($this->getExecuteQueryMethodName($connection))
-            ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement(1, self::TABLES, self::EXCLUDED_TABLES))
+            ->withConsecutive(
+                ...$this->getConsecutiveArgumentsForConnectionExecStatement(1, self::TABLES, self::EXCLUDED_TABLES)
+            )
             ->willReturn(1);
 
         $purger = new ConnectionPurger(
@@ -113,7 +109,6 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 
     public function testThatPurgesWithDeleteMode(): void
     {
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock();
 
         $connection
@@ -129,7 +124,6 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 
     public function testThatPurgesWithTruncateMode(): void
     {
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock(false);
 
         $platform = $this->createMock(AbstractPlatform::class);
@@ -143,9 +137,7 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
                 ['table_3', true]
             )
             ->willReturnOnConsecutiveCalls(
-                ...array_map(function($element) {
-                    return $element[0];
-                }, $this->getTruncateModeConnectionWithConsecutiveArguments())
+                ...array_map(fn ($element) => $element[0], $this->getTruncateModeConnectionWithConsecutiveArguments())
             );
 
         $connection
@@ -167,10 +159,7 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 
     public function testChangePurgeModeToDelete(): void
     {
-        /** @var MockObject|Connection $connection */
-        $connection = $this->getConnectionMock();
-
-        $purger = new ConnectionPurger($connection);
+        $purger = new ConnectionPurger($this->getConnectionMock());
 
         $purger->setPurgeMode(1);
 
@@ -179,10 +168,7 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
 
     public function testChangePurgeModeToTruncate(): void
     {
-        /** @var MockObject|Connection $connection */
-        $connection = $this->getConnectionMock();
-
-        $purger = new ConnectionPurger($connection);
+        $purger = new ConnectionPurger($this->getConnectionMock());
 
         $purger->setPurgeMode(2);
 
@@ -193,10 +179,7 @@ final class ConnectionPurgerTest extends ConnectionPurgerTestCase
     {
         $this->expectException(InvalidConnectionPurgeModeException::class);
 
-        /** @var MockObject|Connection $connection */
-        $connection = $this->getConnectionMock();
-
-        $purger = new ConnectionPurger($connection);
+        $purger = new ConnectionPurger($this->getConnectionMock());
         $purger->setPurgeMode(10);
     }
 }

--- a/tests/Purger/NonTransactionalConnectionPurgerTest.php
+++ b/tests/Purger/NonTransactionalConnectionPurgerTest.php
@@ -3,16 +3,13 @@ declare(strict_types=1);
 
 namespace Kununu\DataFixtures\Tests\Purger;
 
-use Doctrine\DBAL\Connection;
 use Exception;
 use Kununu\DataFixtures\Purger\NonTransactionalConnectionPurger;
-use PHPUnit\Framework\MockObject\MockObject;
 
 final class NonTransactionalConnectionPurgerTest extends ConnectionPurgerTestCase
 {
     public function testThatPurgerIsNotTransactionalAndCommits(): void
     {
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock();
 
         $connection
@@ -37,7 +34,6 @@ final class NonTransactionalConnectionPurgerTest extends ConnectionPurgerTestCas
     {
         $this->expectException(Exception::class);
 
-        /** @var MockObject|Connection $connection */
         $connection = $this->getConnectionMock();
 
         $connection
@@ -45,7 +41,7 @@ final class NonTransactionalConnectionPurgerTest extends ConnectionPurgerTestCas
             ->method($this->getExecuteQueryMethodName($connection))
             ->withConsecutive(...$this->getConsecutiveArgumentsForConnectionExecStatement(1, ['table_1']))
             ->willReturnCallback(function(string $sql): int {
-                if ('DELETE FROM table_1' === $sql) {
+                if ('DELETE FROM `table_1`' === $sql) {
                     throw new Exception();
                 }
 

--- a/tests/TestFixtures/CachePoolFixture1.php
+++ b/tests/TestFixtures/CachePoolFixture1.php
@@ -9,14 +9,14 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class CachePoolFixture1 implements CachePoolFixtureInterface, InitializableFixtureInterface
 {
-    private $arg1;
-    private $arg2;
+    private ?int $arg1 = null;
+    private ?array $arg2 = null;
 
     public function load(CacheItemPoolInterface $cachePool): void
     {
     }
 
-    public function initializeFixture(...$args): void
+    public function initializeFixture(mixed ...$args): void
     {
         foreach ($args as $index => $arg) {
             if (0 === $index && is_int($arg)) {

--- a/tests/Utils/ConnectionUtilsTrait.php
+++ b/tests/Utils/ConnectionUtilsTrait.php
@@ -10,10 +10,6 @@ trait ConnectionUtilsTrait
     public function getExecuteQueryMethodName(Connection $connection): string
     {
         // This way we support both doctrine/dbal ^2.9 and ^3.1
-        if (method_exists($connection, 'executeStatement')) {
-            return 'executeStatement';
-        }
-
-        return 'exec';
+        return method_exists($connection, 'executeStatement') ? 'executeStatement' : 'exec';
     }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to drop support for PHP 7.x as all of those versions are already out of support and to allow future developments not be constrained by those old versions.

<!-- Add more details on your implementation -->
## Details

- Drop support for PHP 7.x
- Small refactors to use PHP 8.0 features
- Change `InitializableFixtureInterface` by typing the `$args` parameter of `initializeFixture` to `mixed`
