### PR TITLE
Add `mixed` as return type of `ElasticSearchFixtureTrait::getDocumentIdForBulkIndexation`

### DIFF
--- a/docs/FixtureTypes/elasticsearch.md
+++ b/docs/FixtureTypes/elasticsearch.md
@@ -67,7 +67,7 @@ final class MyFixture extends ElasticSearchFixture
      * Implement this method to retrieve the document id on Elasticsearch from the document array
      * (or generate one)
      */
-    protected function getDocumentIdForBulkIndexation(array $document)
+    protected function getDocumentIdForBulkIndexation(array $document): mixed
     {
         return sprintf('%d_%s', $document['id'], $document['doc_type']) ;
     }
@@ -176,7 +176,7 @@ final class MyFixture extends ElasticSearchFileFixture
      * Implement this method to retrieve the document id on Elasticsearch from the document array
      * (or generate one)
      */
-    protected function getDocumentIdForBulkIndexation(array $document)
+    protected function getDocumentIdForBulkIndexation(array $document): mixed
     {
         return sprintf('%d_%s', $document['id'], $document['doc_type']) ;
     }
@@ -241,7 +241,7 @@ final class MyFixture extends ElasticSearchFileFixture
      * Implement this method to retrieve the document id on Elasticsearch from the document array
      * (or generate one)
      */
-    protected function getDocumentIdForBulkIndexation(array $document)
+    protected function getDocumentIdForBulkIndexation(array $document): mixed
     {
         return sprintf('%d_%s', $document['id'], $document['doc_type']) ;
     }

--- a/src/Adapter/ElasticSearchFixtureTrait.php
+++ b/src/Adapter/ElasticSearchFixtureTrait.php
@@ -36,5 +36,5 @@ trait ElasticSearchFixtureTrait
         return null;
     }
 
-    abstract protected function getDocumentIdForBulkIndexation(array $document);
+    abstract protected function getDocumentIdForBulkIndexation(array $document): mixed;
 }

--- a/tests/TestFixtures/ElasticSearchArrayDirectoryFixture1.php
+++ b/tests/TestFixtures/ElasticSearchArrayDirectoryFixture1.php
@@ -7,7 +7,7 @@ use Kununu\DataFixtures\Adapter\DirectoryLoader\ElasticSearchArrayDirectoryFixtu
 
 final class ElasticSearchArrayDirectoryFixture1 extends ElasticSearchArrayDirectoryFixture
 {
-    protected function getDocumentIdForBulkIndexation(array $document)
+    protected function getDocumentIdForBulkIndexation(array $document): mixed
     {
         return $document['id'];
     }

--- a/tests/TestFixtures/ElasticSearchFixture3.php
+++ b/tests/TestFixtures/ElasticSearchFixture3.php
@@ -39,7 +39,7 @@ final class ElasticSearchFixture3 extends ElasticSearchFixture
         );
     }
 
-    protected function getDocumentIdForBulkIndexation(array $document)
+    protected function getDocumentIdForBulkIndexation(array $document): mixed
     {
         return $document['id'];
     }

--- a/tests/TestFixtures/ElasticSearchJsonDirectoryFixture1.php
+++ b/tests/TestFixtures/ElasticSearchJsonDirectoryFixture1.php
@@ -7,7 +7,7 @@ use Kununu\DataFixtures\Adapter\DirectoryLoader\ElasticSearchJsonDirectoryFixtur
 
 final class ElasticSearchJsonDirectoryFixture1 extends ElasticSearchJsonDirectoryFixture
 {
-    protected function getDocumentIdForBulkIndexation(array $document)
+    protected function getDocumentIdForBulkIndexation(array $document): mixed
     {
         return $document['uuid'];
     }

--- a/tests/TestFixtures/ElasticSearchJsonDirectoryFixture2.php
+++ b/tests/TestFixtures/ElasticSearchJsonDirectoryFixture2.php
@@ -7,7 +7,7 @@ use Kununu\DataFixtures\Adapter\DirectoryLoader\ElasticSearchJsonDirectoryFixtur
 
 final class ElasticSearchJsonDirectoryFixture2 extends ElasticSearchJsonDirectoryFixture
 {
-    protected function getDocumentIdForBulkIndexation(array $document)
+    protected function getDocumentIdForBulkIndexation(array $document): mixed
     {
         return $document['uuid'];
     }


### PR DESCRIPTION
# Description

The objective of this PR is to add `mixed` as return type of `ElasticSearchFixtureTrait::getDocumentIdForBulkIndexation`

## Details

- Add `mixed` as return type of `ElasticSearchFixtureTrait::getDocumentIdForBulkIndexation`
- Fix tests
- Update docs


