### PR TITLE
Use database platform instead of driver instance.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
     "require-dev": {
         "doctrine/dbal": "^2.9 || ^3.1",
         "elasticsearch/elasticsearch": "^7.0",
+        "kununu/scripts": ">=4.0",
         "phpunit/phpunit": "^9.5",
         "psr/cache": "^1.0",
-        "symfony/phpunit-bridge": "^5.2",
         "symfony/http-client": "^4.4 | ^5.2",
         "symfony/http-foundation": "^4.4 | ^5.2",
-        "kununu/scripts": ">=3.0.1"
+        "symfony/phpunit-bridge": "^5.2"
     },
     "suggest": {
         "psr/cache": "Load fixtures for implementation of the PSR6 standard",

--- a/src/Tools/ConnectionToolsTrait.php
+++ b/src/Tools/ConnectionToolsTrait.php
@@ -5,6 +5,8 @@ namespace Kununu\DataFixtures\Tools;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
@@ -30,10 +32,18 @@ trait ConnectionToolsTrait
     {
         $databasePlatform = $driver->getDatabasePlatform();
 
-        return match (true) {
-            $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=0',
-            $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = OFF',
-            default                                            => '',
+        // This way we support both doctrine/dbal ^2.9 and ^3.1
+        return match (self::dbalSupportsAbstractMySQLPlatform()) {
+            true => match (true) {
+                $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=0',
+                $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = OFF',
+                default                                            => '',
+            },
+            default => match (true) {
+                $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=0',
+                $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = OFF',
+                default                                 => ''
+            }
         };
     }
 
@@ -41,10 +51,23 @@ trait ConnectionToolsTrait
     {
         $databasePlatform = $driver->getDatabasePlatform();
 
-        return match (true) {
-            $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=1',
-            $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = ON',
-            default                                            => '',
+        // This way we support both doctrine/dbal ^2.9 and ^3.1
+        return match (self::dbalSupportsAbstractMySQLPlatform()) {
+            true => match (true) {
+                $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=1',
+                $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = ON',
+                default                                            => '',
+            },
+            default => match (true) {
+                $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=1',
+                $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = ON',
+                default                                 => ''
+            }
         };
+    }
+
+    protected static function dbalSupportsAbstractMySQLPlatform(): bool
+    {
+        return class_exists('Doctrine\DBAL\Platforms\AbstractMySQLPlatform');
     }
 }

--- a/src/Tools/ConnectionToolsTrait.php
+++ b/src/Tools/ConnectionToolsTrait.php
@@ -31,38 +31,26 @@ trait ConnectionToolsTrait
     protected function getDisableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
         $databasePlatform = $driver->getDatabasePlatform();
+        $dbal3 = self::dbalSupportsAbstractMySQLPlatform();
 
         // This way we support both doctrine/dbal ^2.9 and ^3.1
-        return match (self::dbalSupportsAbstractMySQLPlatform()) {
-            true => match (true) {
-                $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=0',
-                $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = OFF',
-                default                                            => '',
-            },
-            default => match (true) {
-                $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=0',
-                $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = OFF',
-                default                                 => ''
-            }
+        return match (true) {
+            ($dbal3 && $databasePlatform instanceof AbstractMySQLPlatform) || (!$dbal3 & $driver instanceof AbstractMySQLDriver) => 'SET FOREIGN_KEY_CHECKS=0',
+            ($dbal3 && $databasePlatform instanceof SqlitePlatform) || (!$dbal3 && $driver instanceof AbstractSQLiteDriver)      => 'PRAGMA foreign_keys = OFF',
+            default                                                                                                              => '',
         };
     }
 
     protected function getEnableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
         $databasePlatform = $driver->getDatabasePlatform();
+        $dbal3 = self::dbalSupportsAbstractMySQLPlatform();
 
         // This way we support both doctrine/dbal ^2.9 and ^3.1
-        return match (self::dbalSupportsAbstractMySQLPlatform()) {
-            true => match (true) {
-                $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=1',
-                $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = ON',
-                default                                            => '',
-            },
-            default => match (true) {
-                $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=1',
-                $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = ON',
-                default                                 => ''
-            }
+        return match (true) {
+            ($dbal3 && $databasePlatform instanceof AbstractMySQLPlatform) || (!$dbal3 && $driver instanceof AbstractMySQLDriver)  => 'SET FOREIGN_KEY_CHECKS=1',
+            ($dbal3 && $databasePlatform instanceof SqlitePlatform) || (!$dbal3 && $driver instanceof AbstractSQLiteDriver)        => 'PRAGMA foreign_keys = ON',
+            default                                                                                                                => '',
         };
     }
 

--- a/src/Tools/ConnectionToolsTrait.php
+++ b/src/Tools/ConnectionToolsTrait.php
@@ -5,8 +5,8 @@ namespace Kununu\DataFixtures\Tools;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
-use Doctrine\DBAL\Driver\AbstractMySQLDriver;
-use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 trait ConnectionToolsTrait
 {
@@ -28,19 +28,23 @@ trait ConnectionToolsTrait
 
     protected function getDisableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
+        $databasePlatform = $driver->getDatabasePlatform();
+
         return match (true) {
-            $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=0',
-            $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = OFF',
-            default                                 => ''
+            $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=0',
+            $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = OFF',
+            default                                            => '',
         };
     }
 
     protected function getEnableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
+        $databasePlatform = $driver->getDatabasePlatform();
+
         return match (true) {
-            $driver instanceof AbstractMySQLDriver  => 'SET FOREIGN_KEY_CHECKS=1',
-            $driver instanceof AbstractSQLiteDriver => 'PRAGMA foreign_keys = ON',
-            default                                 => ''
+            $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=1',
+            $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = ON',
+            default                                            => '',
         };
     }
 }

--- a/src/Tools/ConnectionToolsTrait.php
+++ b/src/Tools/ConnectionToolsTrait.php
@@ -31,31 +31,28 @@ trait ConnectionToolsTrait
     protected function getDisableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
         $databasePlatform = $driver->getDatabasePlatform();
-        $dbal3 = self::dbalSupportsAbstractMySQLPlatform();
 
-        // This way we support both doctrine/dbal ^2.9 and ^3.1
         return match (true) {
-            ($dbal3 && $databasePlatform instanceof AbstractMySQLPlatform) || (!$dbal3 & $driver instanceof AbstractMySQLDriver) => 'SET FOREIGN_KEY_CHECKS=0',
-            ($dbal3 && $databasePlatform instanceof SqlitePlatform) || (!$dbal3 && $driver instanceof AbstractSQLiteDriver)      => 'PRAGMA foreign_keys = OFF',
-            default                                                                                                              => '',
+            $driver instanceof AbstractMySQLDriver,
+            $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=0',
+
+            $driver instanceof AbstractSQLiteDriver,
+            $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = OFF',
+            default                                            => '',
         };
     }
 
     protected function getEnableForeignKeysChecksStatementByDriver(Driver $driver): string
     {
         $databasePlatform = $driver->getDatabasePlatform();
-        $dbal3 = self::dbalSupportsAbstractMySQLPlatform();
 
-        // This way we support both doctrine/dbal ^2.9 and ^3.1
         return match (true) {
-            ($dbal3 && $databasePlatform instanceof AbstractMySQLPlatform) || (!$dbal3 && $driver instanceof AbstractMySQLDriver)  => 'SET FOREIGN_KEY_CHECKS=1',
-            ($dbal3 && $databasePlatform instanceof SqlitePlatform) || (!$dbal3 && $driver instanceof AbstractSQLiteDriver)        => 'PRAGMA foreign_keys = ON',
-            default                                                                                                                => '',
-        };
-    }
+            $driver instanceof AbstractMySQLDriver,
+            $databasePlatform instanceof AbstractMySQLPlatform => 'SET FOREIGN_KEY_CHECKS=1',
 
-    protected static function dbalSupportsAbstractMySQLPlatform(): bool
-    {
-        return class_exists('Doctrine\DBAL\Platforms\AbstractMySQLPlatform');
+            $driver instanceof AbstractSQLiteDriver,
+            $databasePlatform instanceof SqlitePlatform        => 'PRAGMA foreign_keys = ON',
+            default                                            => '',
+        };
     }
 }

--- a/tests/Executor/ConnectionExecutorTest.php
+++ b/tests/Executor/ConnectionExecutorTest.php
@@ -139,7 +139,7 @@ final class ConnectionExecutorTest extends AbstractExecutorTestCase
         $this->connection
             ->expects($this->any())
             ->method('getDriver')
-            ->willReturn($this->createMock(AbstractMySQLDriver::class));
+            ->willReturn($this->getMockForAbstractClass(AbstractMySQLDriver::class));
 
         parent::setUp();
     }

--- a/tests/Executor/NonTransactionalConnectionExecutorTest.php
+++ b/tests/Executor/NonTransactionalConnectionExecutorTest.php
@@ -101,7 +101,7 @@ final class NonTransactionalConnectionExecutorTest extends AbstractExecutorTestC
         $this->connection
             ->expects($this->any())
             ->method('getDriver')
-            ->willReturn($this->createMock(AbstractMySQLDriver::class));
+            ->willReturn($this->getMockForAbstractClass(AbstractMySQLDriver::class));
 
         parent::setUp();
     }

--- a/tests/Purger/AbstractConnectionPurgerTestCase.php
+++ b/tests/Purger/AbstractConnectionPurgerTestCase.php
@@ -37,7 +37,7 @@ abstract class AbstractConnectionPurgerTestCase extends TestCase
         $connection
             ->expects($this->any())
             ->method('getDriver')
-            ->willReturn($this->createMock(AbstractMySQLDriver::class));
+            ->willReturn($this->getMockForAbstractClass(AbstractMySQLDriver::class));
 
         $connection
             ->expects($this->any())

--- a/tests/Tools/ConnectionToolsTest.php
+++ b/tests/Tools/ConnectionToolsTest.php
@@ -122,4 +122,9 @@ final class ConnectionToolsTest extends TestCase
     {
         return is_string($driver) ? $this->createMock($driver) : $driver;
     }
+
+    private static function dbalSupportsAbstractMySQLPlatform(): bool
+    {
+        return class_exists('\Doctrine\DBAL\Platforms\AbstractMySQLPlatform');
+    }
 }

--- a/tests/Tools/ConnectionToolsTest.php
+++ b/tests/Tools/ConnectionToolsTest.php
@@ -6,42 +6,56 @@ namespace Kununu\DataFixtures\Tests\Tools;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+use Doctrine\DBAL\Logging\Middleware;
 use Kununu\DataFixtures\Tools\ConnectionToolsTrait;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 final class ConnectionToolsTest extends TestCase
 {
     use ConnectionToolsTrait;
 
-    public function testGetDisableForeignKeyChecksForMySQL(): void
+    /**
+     * @dataProvider provideMySQLDrivers
+     */
+    public function testGetDisableForeignKeyChecksForMySQL(Driver $driver): void
     {
         $this->assertEquals(
             'SET FOREIGN_KEY_CHECKS=0',
-            $this->getDisableForeignKeysChecksStatementByDriver($this->createMock(AbstractMySQLDriver::class))
+            $this->getDisableForeignKeysChecksStatementByDriver($driver),
         );
     }
 
-    public function testGetEnableForeignKeyChecksForMySQL(): void
+    /**
+     * @dataProvider provideMySQLDrivers
+     */
+    public function testGetEnableForeignKeyChecksForMySQL(Driver $driver): void
     {
         $this->assertEquals(
             'SET FOREIGN_KEY_CHECKS=1',
-            $this->getEnableForeignKeysChecksStatementByDriver($this->createMock(AbstractMySQLDriver::class))
+            $this->getEnableForeignKeysChecksStatementByDriver($driver),
         );
     }
 
-    public function testGetDisableForeignKeyChecksForSqlite(): void
+    /**
+     * @dataProvider provideSQLiteDrivers
+     */
+    public function testGetDisableForeignKeyChecksForSqlite(Driver $driver): void
     {
         $this->assertEquals(
             'PRAGMA foreign_keys = OFF',
-            $this->getDisableForeignKeysChecksStatementByDriver($this->createMock(AbstractSQLiteDriver::class))
+            $this->getDisableForeignKeysChecksStatementByDriver($driver)
         );
     }
 
-    public function testGetEnableForeignKeyChecksForSqlite(): void
+    /**
+     * @dataProvider provideSQLiteDrivers
+     */
+    public function testGetEnableForeignKeyChecksForSqlite(Driver $driver): void
     {
         $this->assertEquals(
             'PRAGMA foreign_keys = ON',
-            $this->getEnableForeignKeysChecksStatementByDriver($this->createMock(AbstractSQLiteDriver::class))
+            $this->getEnableForeignKeysChecksStatementByDriver($driver)
         );
     }
 
@@ -59,5 +73,41 @@ final class ConnectionToolsTest extends TestCase
             '',
             $this->getDisableForeignKeysChecksStatementByDriver($this->createMock(Driver::class))
         );
+    }
+
+    /**
+     * @return array<string, array{Driver}>
+     */
+    public static function provideMySQLDrivers(): array
+    {
+        $abstractMySQLDriver = new class() extends AbstractMySQLDriver {
+            public function connect(array $params)
+            {
+                return null;
+            }
+        };
+
+        return [
+            'abstract mysql driver'                               => [$abstractMySQLDriver],
+            'abstract mysql driver wrapped in logging middleware' => [(new Middleware(new NullLogger()))->wrap($abstractMySQLDriver)],
+        ];
+    }
+
+    /**
+     * @return array<string, array{Driver}>
+     */
+    public static function provideSQLiteDrivers(): array
+    {
+        $abstractSQLiteDriver = new class() extends AbstractSQLiteDriver {
+            public function connect(array $params)
+            {
+                return null;
+            }
+        };
+
+        return [
+            'abstract sqlite driver'                               => [$abstractSQLiteDriver],
+            'abstract sqlite driver wrapped in logging middleware' => [(new Middleware(new NullLogger()))->wrap($abstractSQLiteDriver)],
+        ];
     }
 }


### PR DESCRIPTION
So that the correct foreign key checks statement is determined even if driver is wrapped in a middleware.

# Description
In major version 3, https://github.com/doctrine/dbal introduced [Middlewares](https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/architecture.html#middlewares).
These are implemented following Decorator Pattern, which means we can't identify the database platform with a Driver class instance check (to determine the correct enable/disable foreign keys statement).

The objective of this PR is to change the way we determine the driver platform (MySQL/SQLite) so that it works even if the Driver is decorated with a middleware, by instance checking the Database Platform object class instead of the Driver object class.