### PR TITLE
Introduce body validator for HttpClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     },
     "scripts": {
         "test": "phpunit --no-coverage tests",
-        "test-coverage": "phpunit --coverage-clover tests/.results/coverage.xml --coverage-html tests/.results/html/ tests"
+        "test-coverage": "XDEBUG_MODE=coverage phpunit --coverage-clover tests/.results/coverage.xml --coverage-html tests/.results/html/ tests"
     },
     "scripts-descriptions": {
         "test": "Run all tests",

--- a/docs/FixtureTypes/symfony-http-client.md
+++ b/docs/FixtureTypes/symfony-http-client.md
@@ -51,10 +51,21 @@ declare(strict_types=1);
 //
 // Format:
 // [
-//      'url'       => Url of the request (REQUIRED)
-//      'method'    => Http method (default: GET)
-//      'code'      => Http code to return (default: 200)
-//      'body'      => Body of the response (default: an empty string)
+//      'url'           => Url of the request (REQUIRED)
+//      'method'        => Http method (default: GET)
+//      'code'          => Http code to return (default: 200)
+//      'body'          => Body of the response (default: an empty string)
+//      'bodyValidator' => A callable to validate the body (e.g. in POST requests) and change the response
+//                         based on the body contents (default: null)
+//
+//                         The callable has the following signature:
+// 
+//                         function(MockResponse $response, array $options = []): MockResponse
+//                          
+//                          - $response - The MockResponse object that is the "normal" response
+//                          - $options  - The request options (which contains the body, auth headers, etc.)
+//
+//                          Return value: A MockResponse object which can be the original or a new one
 // ]
 //
 return [    
@@ -76,6 +87,24 @@ return [
 }
 JSON
         ,
+    [
+        'url'           => 'https://my.server/data',
+        'method'        => 'POST',
+        // Example of how to manipulate the response based on the body context
+        'bodyValidator' => function(MockResponse $response, array $options = []): MockResponse {
+            // Get the id from the json body if available
+            $id = $options['json']['id'] ?? null;
+
+            // We only want a "good" response for a specific id
+            if ($id === 5000) {
+                return $response;
+            }
+
+            // For all other cases return a 404
+            return new MockResponse('', ['http_code' => Response::HTTP_NOT_FOUND]);
+        
+        }        
+    ],
     ],
 ];
 ```

--- a/tests/Tools/HttpClientTest.php
+++ b/tests/Tools/HttpClientTest.php
@@ -13,26 +13,23 @@ final class HttpClientTest extends TestCase
     private const REQUEST_1 = 'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data';
     private const REQUEST_2 = 'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data';
 
-    private const RESPONSES = [
-        [
-            'url'  => 'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data',
-            'code' => 404,
-        ],
-        [
-            'url'  => 'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data',
-            'body' => '{"id":1000,"name":{"first":"The","surname":"Name"},"age":39,"newsletter":true}',
-        ],
-    ];
-
     public function testHttpClient(): void
     {
         $httpClient = new HttpClient();
-        $httpClient->addResponses(self::RESPONSES);
+        $httpClient->addResponses(require_once __DIR__ . '/responses.php');
 
         $response = $httpClient->request(Request::METHOD_GET, self::REQUEST_1);
         $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
 
-        $response = $httpClient->request(Request::METHOD_GET, self::REQUEST_2);
+        $response = $httpClient->request(
+            Request::METHOD_POST,
+            self::REQUEST_2,
+            [
+                'json' => [
+                    'id' => 5000,
+                ],
+            ]
+        );
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertJsonStringEqualsJsonString(
             <<<'JSON'
@@ -49,6 +46,10 @@ JSON
             ,
             $response->getContent()
         );
+
+        $response = $httpClient->request(Request::METHOD_POST, self::REQUEST_2);
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertEmpty($response->getContent(false));
 
         $httpClient->clearResponses();
 

--- a/tests/Tools/responses.php
+++ b/tests/Tools/responses.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+return [
+    [
+        'url'  => 'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data',
+        'code' => 404,
+    ],
+    [
+        'url'           => 'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data',
+        'method'        => 'POST',
+        'body'          => <<<'JSON'
+{
+  "id": 1000,
+  "name": {
+    "first": "The",
+    "surname": "Name"
+  },
+  "age": 39,
+  "newsletter": true
+}
+JSON
+        ,
+        'bodyValidator' => function(MockResponse $response, array $options = []): MockResponse {
+            $id = $options['json']['id'] ?? null;
+
+            if ($id === 5000) {
+                return $response;
+            }
+
+            return new MockResponse('', ['http_code' => Response::HTTP_NOT_FOUND]);
+        },
+    ],
+];


### PR DESCRIPTION
# Description

The objective of this PR is to allow to validate and manipulate the response for requests where parameters are sent in the body (e.g. POST requests) and not via path and/or query parameters.

This will allow more flexibility when addressing those cases.

## Details
- Allow to define a body validator on `HttpClient` responses configuration
- Add test case for the change
- Update documentation
