### PR TITLE
Update continuous integration components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     # Disable automatic rebasing to prevent overloading our CICD system
     rebase-strategy: "disabled"
     versioning-strategy: auto
-    # By default Dependabot has a limit of the number of open PR for version updates
+    # By default, Dependabot has a limit of the number of open PR for version updates
     # and security updates.
     # See other defaults in here: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -42,23 +42,23 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Upload coverage files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}-${{ matrix.php-version }}-coverage
+          name: ${{ github.job }}-${{ matrix.php-version }}-${{ matrix.dependencies }}-coverage
           path: tests/.results/
 
   sonarcloud:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
-          name: build-8-coverage
+          name: build-8-highest-coverage
           path: tests/.results/
 
       - name: Fix Code Coverage Paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 Contributions are more than **welcome**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/kununu/data-fixtures).
+We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/data-fixtures).
 
 ## Pull Requests
 
 - **[kununu Coding Standards](https://github.com/kununu/kununu-scripts)** - The kununu coding standards are an extension of the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md). Check out [kununu Coding Standards](https://github.com/kununu/kununu-scripts) for more details. In development mode the package [kununu-scripts](https://github.com/kununu/kununu-scripts) is already a dependency that expose commands that you can use to meet our standards.
 
-- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it doesn't have tests.
+- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
 
 - **Document any change in behaviour** - Make sure the `CHANGELOG.md`, `README.md` and any other relevant documentation are kept up-to-date.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,20 +1,24 @@
 # Security Policy
 
+## For external contributors
 
-## Reporting a Vulnerability
+If you want to report any security vulnerabilities please do so by creating an [issue](https://github.com/kununu/data-fixtues/issues).
+Additionally, if you have a fix then please create a pull request and link it to the issue you have created.
 
-Jira is our entrypoint to report security vulnerabilities. Having this mind a KUNSECU user story (type Vulnerability) needs to be created.
+## For kununu developers
 
-### How to fill the user story?
+### Reporting a Vulnerability
 
-Follow this [documentation](https://confluence.xing.hh/pages/viewpage.action?pageId=381133070).
+Jira is our entrypoint to report security vulnerabilities. Having this in mind a KUNSECU user story (type Vulnerability) needs to be created.
 
+#### How to fill the user story?
 
-### To which team do I assign the user story?
+Follow this [documentation](https://new-work.atlassian.net/wiki/spaces/kununu/pages/47846323/Vulnerability+Issue+Type+Jira).
 
-Follow the [component ownership matrix](https://confluence.xing.hh/display/kununu/Component+ownership+and+support) and assign it to the corresponding team.
+#### To which team do I assign the user story?
 
+Follow the [domain ownership matrix](https://new-work.atlassian.net/wiki/spaces/kununu/pages/113148000/Domain+ownership+matrix) and assign it to the corresponding team.
 
 ## Reporting the update of dependencies
 
-This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the Github [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).
+This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the GitHub [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).

--- a/composer.json
+++ b/composer.json
@@ -1,69 +1,70 @@
 {
-    "name": "kununu/data-fixtures",
-    "description": "Load data fixtures in your application for any storage",
-    "type": "library",
-    "license": "MIT",
-    "require": {
-        "php": ">=8.0",
-        "ext-json": "*"
+  "name": "kununu/data-fixtures",
+  "description": "Load data fixtures in your application for any storage",
+  "type": "library",
+  "license": "MIT",
+  "minimum-stability": "stable",
+  "keywords": [
+    "database",
+    "data fixtures",
+    "Doctrine",
+    "Elasticsearch",
+    "PSR-6 Cache"
+  ],
+  "authors": [
+    {
+      "name": "Hugo Gonçalves",
+      "email": "hugo.goncalves@kununu.com"
     },
-    "keywords": [
-        "database",
-        "data fixtures",
-        "Doctrine",
-        "Elasticsearch",
-        "PSR-6 Cache"
-    ],
-    "authors": [
-        {
-            "name": "Hugo Gonçalves",
-            "email": "hugo.goncalves@kununu.com"
-        },
-        {
-            "name": "João Alves",
-            "email": "joao.alves@kununu.com"
-        }
-    ],
-    "require-dev": {
-        "doctrine/dbal": "^2.9 || ^3.1",
-        "elasticsearch/elasticsearch": "^7.0",
-        "kununu/scripts": ">=4.0",
-        "phpunit/phpunit": "^9.5",
-        "psr/cache": "^1.0",
-        "symfony/http-client": "^4.4 | ^5.2",
-        "symfony/http-foundation": "^4.4 | ^5.2",
-        "symfony/phpunit-bridge": "^5.2"
-    },
-    "suggest": {
-        "psr/cache": "Load fixtures for implementation of the PSR6 standard",
-        "doctrine/dbal": "Load fixtures using Doctrine DBAL",
-        "elasticsearch/elasticsearch": "Load fixtures with Elasticsearch",
-        "kununu/testing-bundle": "Use this package in a Symfony application",
-        "symfony/http-client": "Load fixtures with mocked data for Symfony Http client",
-        "symfony/http-foundation": "Load fixtures with mocked data for Symfony Http client"
-    },
-    "autoload": {
-        "psr-4": {
-            "Kununu\\DataFixtures\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Kununu\\DataFixtures\\Tests\\": "tests/"
-        }
-    },
-    "scripts": {
-        "test": "phpunit --no-coverage tests",
-        "test-coverage": "XDEBUG_MODE=coverage phpunit --coverage-clover tests/.results/coverage.xml --coverage-html tests/.results/html/ tests"
-    },
-    "scripts-descriptions": {
-        "test": "Run all tests",
-        "test-coverage": "Run all tests with coverage report"
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "kununu/scripts": true
-        }
+    {
+      "name": "João Alves",
+      "email": "joao.alves@kununu.com"
     }
+  ],
+  "require": {
+    "php": ">=8.0",
+    "ext-json": "*"
+  },
+  "require-dev": {
+    "doctrine/dbal": "^2.9 || ^3.1",
+    "elasticsearch/elasticsearch": "^7.0",
+    "kununu/scripts": ">=4.0",
+    "phpunit/phpunit": "^9.5",
+    "psr/cache": "^1.0",
+    "symfony/http-client": "^4.4 | ^5.2",
+    "symfony/http-foundation": "^4.4 | ^5.2",
+    "symfony/phpunit-bridge": "^5.2"
+  },
+  "suggest": {
+    "psr/cache": "Load fixtures for implementation of the PSR6 standard",
+    "doctrine/dbal": "Load fixtures using Doctrine DBAL",
+    "elasticsearch/elasticsearch": "Load fixtures with Elasticsearch",
+    "kununu/testing-bundle": "Use this package in a Symfony application",
+    "symfony/http-client": "Load fixtures with mocked data for Symfony Http client",
+    "symfony/http-foundation": "Load fixtures with mocked data for Symfony Http client"
+  },
+  "autoload": {
+    "psr-4": {
+      "Kununu\\DataFixtures\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Kununu\\DataFixtures\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit --no-coverage tests",
+    "test-coverage": "XDEBUG_MODE=coverage phpunit --coverage-clover tests/.results/coverage.xml --coverage-html tests/.results/html/ tests"
+  },
+  "scripts-descriptions": {
+    "test": "Run all tests",
+    "test-coverage": "Run all tests with coverage report"
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "kununu/scripts": true
+    }
+  }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to update the components used in continuous integration GitHub actions

## Details
- Update continuous integration components:
  - `actions/checkout` to v4
  - `ramsey/composer-install` to v2
  - `actions/upload-artifact` to v4
  - `actions/download-artifact` to v4
- Update links and typos in documentation
