### PR TITLE
Fix building error message in ElasticsearchFileFixture

### DIFF
--- a/src/Adapter/ElasticsearchFileFixture.php
+++ b/src/Adapter/ElasticsearchFileFixture.php
@@ -35,16 +35,8 @@ abstract class ElasticsearchFileFixture extends AbstractFileLoaderFixture implem
 
         if ($throwOnFail && ($result['errors'] ?? false)) {
             $errors = array_map(
-                fn(array $item): stdClass => (object) [
-                    self::INDEX => $item[self::UPDATE]['_index'],
-                    'id'        => $item[self::UPDATE]['_id'],
-                    'status'    => $item[self::UPDATE]['status'],
-                    self::ERROR => $item[self::UPDATE][self::ERROR],
-                ],
-                array_filter(
-                    $result['items'] ?? [],
-                    fn(array $item): bool => isset($item[self::UPDATE][self::ERROR])
-                )
+                fn(array $item): stdClass => (object) $item,
+                array_filter($result['items'] ?? [])
             );
 
             throw new LoadFailedException(static::class, $errors);

--- a/src/Adapter/ElasticsearchFileFixture.php
+++ b/src/Adapter/ElasticsearchFileFixture.php
@@ -11,10 +11,6 @@ abstract class ElasticsearchFileFixture extends AbstractFileLoaderFixture implem
 {
     use ElasticsearchFixtureTrait;
 
-    private const INDEX = 'index';
-    private const UPDATE = 'update';
-    private const ERROR = 'error';
-
     public function load(Client $elasticSearch, string $indexName, bool $throwOnFail = true): void
     {
         parent::loadFiles(fn(array $documents) => $this->bulk($elasticSearch, $indexName, $documents, $throwOnFail));

--- a/tests/Adapter/ElasticsearchJsonDirectoryFixtureTest.php
+++ b/tests/Adapter/ElasticsearchJsonDirectoryFixtureTest.php
@@ -120,25 +120,6 @@ final class ElasticsearchJsonDirectoryFixtureTest extends TestCase
                 ],
             ],
         ];
-        $bulk2 = [
-            'body' => [
-                [
-                    'index' => [
-                        '_index' => 'my_index',
-                        '_id'    => 'd1cd10a0-7023-434c-8cd3-0196e1d34c2f',
-                    ],
-                ],
-                [
-                    'uuid'       => 'd1cd10a0-7023-434c-8cd3-0196e1d34c2f',
-                    'name'       => 'Document 3',
-                    'attributes' => [
-                        'attrib_1' => 3,
-                        'attrib_2' => 'inactive',
-                        'attrib_3' => false,
-                    ],
-                ],
-            ],
-        ];
 
         $this->client
             ->expects($this->once())
@@ -168,10 +149,12 @@ final class ElasticsearchJsonDirectoryFixtureTest extends TestCase
 Errors:
 [
     {
-        "index": "my_index",
-        "id": "17e05f79-2c6e-4a71-bacf-afc8fd8e5f73",
-        "status": "some status",
-        "error": "some error"
+        "update": {
+            "error": "some error",
+            "_index": "my_index",
+            "_id": "17e05f79-2c6e-4a71-bacf-afc8fd8e5f73",
+            "status": "some status"
+        }
     }
 ]
 TEXT


### PR DESCRIPTION
# Description

The objective of this PR is to fix the error message that is sent with the `LoadFailedException` on `ElasticsearchFileFixture` if `$throwOnFail` parameter is true and errors occur during the bulk insertion to Elasticsearch. 
