### PR TITLE
Make even more properties read-only

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,7 @@ jobs:
           coverage: xdebug
 
       - name: Install Composer Dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: "--prefer-stable"

--- a/src/Executor/CachePoolExecutor.php
+++ b/src/Executor/CachePoolExecutor.php
@@ -9,8 +9,10 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class CachePoolExecutor implements ExecutorInterface
 {
-    public function __construct(private CacheItemPoolInterface $cache, private PurgerInterface $purger)
-    {
+    public function __construct(
+        private readonly CacheItemPoolInterface $cache,
+        private readonly PurgerInterface $purger
+    ) {
     }
 
     public function execute(array $fixtures, bool $append = false): void

--- a/src/Executor/ElasticsearchExecutor.php
+++ b/src/Executor/ElasticsearchExecutor.php
@@ -10,9 +10,9 @@ use Kununu\DataFixtures\Purger\PurgerInterface;
 final class ElasticsearchExecutor implements ExecutorInterface
 {
     public function __construct(
-        private Client $elasticSearch,
-        private string $indexName,
-        private PurgerInterface $purger
+        private readonly Client $elasticSearch,
+        private readonly string $indexName,
+        private readonly PurgerInterface $purger
     ) {
     }
 

--- a/src/Executor/HttpClientExecutor.php
+++ b/src/Executor/HttpClientExecutor.php
@@ -9,8 +9,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class HttpClientExecutor implements ExecutorInterface
 {
-    public function __construct(private HttpClientInterface $httpClient, private PurgerInterface $purger)
-    {
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly PurgerInterface $purger
+    ) {
     }
 
     public function execute(array $fixtures, bool $append = false): void

--- a/src/Executor/NonTransactionalConnectionExecutor.php
+++ b/src/Executor/NonTransactionalConnectionExecutor.php
@@ -8,7 +8,7 @@ use Kununu\DataFixtures\Purger\PurgerInterface;
 
 final class NonTransactionalConnectionExecutor implements ExecutorInterface
 {
-    private ExecutorInterface $executor;
+    private readonly ExecutorInterface $executor;
 
     public function __construct(Connection $connection, PurgerInterface $purger)
     {

--- a/src/Purger/CachePoolPurger.php
+++ b/src/Purger/CachePoolPurger.php
@@ -8,7 +8,7 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class CachePoolPurger implements PurgerInterface
 {
-    public function __construct(private CacheItemPoolInterface $cachePool)
+    public function __construct(private readonly CacheItemPoolInterface $cachePool)
     {
     }
 

--- a/src/Purger/ElasticsearchPurger.php
+++ b/src/Purger/ElasticsearchPurger.php
@@ -8,7 +8,7 @@ use stdClass;
 
 final class ElasticsearchPurger implements PurgerInterface
 {
-    public function __construct(private Client $elasticSearch, private string $indexName)
+    public function __construct(private readonly Client $elasticSearch, private readonly string $indexName)
     {
     }
 

--- a/src/Purger/HttpClientPurger.php
+++ b/src/Purger/HttpClientPurger.php
@@ -8,7 +8,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class HttpClientPurger implements PurgerInterface
 {
-    public function __construct(private HttpClientInterface $httpClient)
+    public function __construct(private readonly HttpClientInterface $httpClient)
     {
     }
 

--- a/src/Purger/NonTransactionalConnectionPurger.php
+++ b/src/Purger/NonTransactionalConnectionPurger.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Connection;
 
 final class NonTransactionalConnectionPurger implements PurgerInterface
 {
-    private PurgerInterface $purger;
+    private readonly PurgerInterface $purger;
 
     public function __construct(Connection $connection, array $excludedTables = [])
     {

--- a/src/Tools/HttpClient.php
+++ b/src/Tools/HttpClient.php
@@ -82,7 +82,6 @@ final class HttpClient extends MockHttpClient implements FixturesHttpClientInter
 
         $reflectionClass = new ReflectionClass(MockHttpClient::class);
         $reflectionProperty = $reflectionClass->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($this, $responseFactory);
     }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to make more properties read-only following the update to >= PHP 8.1 only

## Details
- Make even more properties read-only
- Update ramsey/composer-install to v3 on github actions
