### PR TITLE
Bump minimum PHP version to 8.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           coverage: none
           tools: composer-dependency-analyser, composer-normalize, composer-require-checker, cs2pr
 
@@ -60,14 +60,13 @@ jobs:
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --ansi
 
-  build:
+  tests:
     needs: checks
-    name: PHPUnit
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php-version:
-          - 8.3
           - 8.4
         dependencies:
           - lowest
@@ -102,19 +101,18 @@ jobs:
           include-hidden-files: true
           path: tests/.results/
 
-  sonarcloud:
-    needs: build
-    name: SonarCloud Checks
+  code_analysis:
+    needs: tests
+    name: Code Analysis
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-8.3-highest-coverage
+          name: tests-8.4-highest-coverage
           path: tests/.results/
 
       - name: Fix Code Coverage Paths

--- a/composer.json
+++ b/composer.json
@@ -23,23 +23,23 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
+    "php": ">=8.4",
     "ext-json": "*",
     "composer/semver": "^3.4"
   },
   "require-dev": {
     "aws/aws-sdk-php": "^3.173",
-    "doctrine/dbal": "^3.10 || ^4.3",
+    "doctrine/dbal": "^3.10 || ^4.4",
     "elasticsearch/elasticsearch": "^7.1",
     "jetbrains/phpstorm-attributes": "^1.2",
-    "kununu/code-tools": "^3.1",
+    "kununu/code-tools": "^4.0",
     "nyholm/psr7": "^1.8",
     "opensearch-project/opensearch-php": "^2.0",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
     "phpunit/phpunit": "^12.5",
     "psr/cache": "^2.0",
-    "rector/rector": "^2.2",
+    "rector/rector": "^2.3",
     "shipmonk/composer-dependency-analyser": "^1.8",
     "symfony/http-client": "^6.4 || ^7.4",
     "symfony/http-foundation": "^6.4 || ^7.4"

--- a/rector-ci.php
+++ b/rector-ci.php
@@ -5,10 +5,11 @@ use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
+use Rector\PHPUnit\PHPUnit120\Rector\Class_\PropertyCreateMockToCreateStubRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 
 return RectorConfig::configure()
-    ->withPhpSets(php83: true)
+    ->withPhpSets(php84: true)
     ->withAttributesSets(phpunit: true)
     ->withComposerBased(phpunit: true)
     ->withRules([
@@ -18,6 +19,10 @@ return RectorConfig::configure()
     ->withSkip([
         __DIR__ . '/rector-ci.php',
         AddOverrideAttributeToOverriddenMethodsRector::class,
+        PropertyCreateMockToCreateStubRector::class => [
+            __DIR__ . '/tests/Executor/AbstractExecutorTestCase.php',
+            __DIR__ . '/tests/Purger/AbstractConnectionPurgerTestCase.php',
+        ],
         StringClassNameToClassConstantRector::class => [
             __DIR__ . '/src/Tools/DoctrineDbal/Version.php',
         ],

--- a/src/Adapter/DirectoryLoader/DirectoryFileSearchTrait.php
+++ b/src/Adapter/DirectoryLoader/DirectoryFileSearchTrait.php
@@ -40,6 +40,6 @@ trait DirectoryFileSearchTrait
     {
         [, , $feature] = array_slice(explode('\\', static::class), -3);
 
-        return sprintf('%s/%s/%s', dirname((new ReflectionClass($this))->getFilename()), $subDirectory, $feature);
+        return sprintf('%s/%s/%s', dirname(new ReflectionClass($this)->getFilename()), $subDirectory, $feature);
     }
 }

--- a/tests/Adapter/ElasticsearchArrayDirectoryFixtureTest.php
+++ b/tests/Adapter/ElasticsearchArrayDirectoryFixtureTest.php
@@ -83,7 +83,7 @@ final class ElasticsearchArrayDirectoryFixtureTest extends TestCase
             )
             ->willReturn(['errors' => false]);
 
-        (new ElasticsearchArrayDirectoryFixture1())->load($this->client, 'my_index');
+        new ElasticsearchArrayDirectoryFixture1()->load($this->client, 'my_index');
     }
 
     protected function setUp(): void

--- a/tests/Adapter/ElasticsearchFixtureTest.php
+++ b/tests/Adapter/ElasticsearchFixtureTest.php
@@ -53,7 +53,7 @@ final class ElasticsearchFixtureTest extends TestCase
                 ],
             ]);
 
-        (new ElasticsearchFixture3())->load($this->client, 'my_index');
+        new ElasticsearchFixture3()->load($this->client, 'my_index');
     }
 
     protected function setUp(): void

--- a/tests/Adapter/ElasticsearchJsonDirectoryFixtureTest.php
+++ b/tests/Adapter/ElasticsearchJsonDirectoryFixtureTest.php
@@ -81,7 +81,7 @@ final class ElasticsearchJsonDirectoryFixtureTest extends TestCase
             )
             ->willReturn(['errors' => false]);
 
-        (new ElasticsearchJsonDirectoryFixture1())->load($this->client, 'my_index');
+        new ElasticsearchJsonDirectoryFixture1()->load($this->client, 'my_index');
     }
 
     public function testLoadWithErrors(): void
@@ -160,7 +160,7 @@ Errors:
 TEXT
         );
 
-        (new ElasticsearchJsonDirectoryFixture1())->load($this->client, 'my_index');
+        new ElasticsearchJsonDirectoryFixture1()->load($this->client, 'my_index');
     }
 
     public function testLoadWithInvalidJson(): void
@@ -212,7 +212,7 @@ TEXT
             )
         );
 
-        (new ElasticsearchJsonDirectoryFixture2())->load($this->client, 'my_index');
+        new ElasticsearchJsonDirectoryFixture2()->load($this->client, 'my_index');
     }
 
     protected function setUp(): void

--- a/tests/Adapter/HttpClientPhpArrayFixtureTest.php
+++ b/tests/Adapter/HttpClientPhpArrayFixtureTest.php
@@ -54,7 +54,7 @@ JSON,
 
         $this->expectException(InvalidFileException::class);
 
-        (new InvalidHttpClientFixture())->load($this->httpClient);
+        new InvalidHttpClientFixture()->load($this->httpClient);
     }
 
     public function testInvalidFile(): void
@@ -65,7 +65,7 @@ JSON,
 
         $this->expectException(InvalidFileException::class);
 
-        (new HttpClientFixture2())->load($this->httpClient);
+        new HttpClientFixture2()->load($this->httpClient);
     }
 
     public function testNotAFixtureHttpClient(): void

--- a/tests/Adapter/OpenSearchArrayDirectoryFixtureTest.php
+++ b/tests/Adapter/OpenSearchArrayDirectoryFixtureTest.php
@@ -78,7 +78,7 @@ final class OpenSearchArrayDirectoryFixtureTest extends TestCase
             )
             ->willReturn(['errors' => false]);
 
-        (new OpenSearchArrayDirectoryFixture1())->load($this->client, 'my_index');
+        new OpenSearchArrayDirectoryFixture1()->load($this->client, 'my_index');
     }
 
     protected function setUp(): void

--- a/tests/Adapter/OpenSearchFixtureTest.php
+++ b/tests/Adapter/OpenSearchFixtureTest.php
@@ -52,7 +52,7 @@ final class OpenSearchFixtureTest extends TestCase
                 ],
             ]);
 
-        (new OpenSearchFixture3())->load($this->client, 'my_index');
+        new OpenSearchFixture3()->load($this->client, 'my_index');
     }
 
     protected function setUp(): void

--- a/tests/Adapter/OpenSearchJsonDirectoryFixtureTest.php
+++ b/tests/Adapter/OpenSearchJsonDirectoryFixtureTest.php
@@ -81,7 +81,7 @@ final class OpenSearchJsonDirectoryFixtureTest extends TestCase
             )
             ->willReturn(['errors' => false]);
 
-        (new OpenSearchJsonDirectoryFixture1())->load($this->client, 'my_index');
+        new OpenSearchJsonDirectoryFixture1()->load($this->client, 'my_index');
     }
 
     public function testLoadWithErrors(): void
@@ -160,7 +160,7 @@ Errors:
 TEXT
         );
 
-        (new OpenSearchJsonDirectoryFixture1())->load($this->client, 'my_index');
+        new OpenSearchJsonDirectoryFixture1()->load($this->client, 'my_index');
     }
 
     public function testLoadWithInvalidJson(): void
@@ -212,7 +212,7 @@ TEXT
             )
         );
 
-        (new OpenSearchJsonDirectoryFixture2())->load($this->client, 'my_index');
+        new OpenSearchJsonDirectoryFixture2()->load($this->client, 'my_index');
     }
 
     protected function setUp(): void

--- a/tests/Loader/AbstractLoaderTestCase.php
+++ b/tests/Loader/AbstractLoaderTestCase.php
@@ -141,6 +141,6 @@ abstract class AbstractLoaderTestCase extends TestCase
 
     private function generateMockClassName(string $prefix): string
     {
-        return sprintf('%s%s', $prefix, md5((new DateTime())->format('Y-m-d H:i:s.uP')));
+        return sprintf('%s%s', $prefix, md5(new DateTime()->format('Y-m-d H:i:s.uP')));
     }
 }

--- a/tests/Purger/ConnectionPurgerTest.php
+++ b/tests/Purger/ConnectionPurgerTest.php
@@ -182,6 +182,6 @@ final class ConnectionPurgerTest extends AbstractConnectionPurgerTestCase
 
     private function purge(array $excludedTables = [], PurgeMode $purgeMode = PurgeMode::Delete): void
     {
-        (new ConnectionPurger($this->connection, $excludedTables, purgeMode: $purgeMode))->purge();
+        new ConnectionPurger($this->connection, $excludedTables, purgeMode: $purgeMode)->purge();
     }
 }

--- a/tests/Purger/NonTransactionalConnectionPurgerTest.php
+++ b/tests/Purger/NonTransactionalConnectionPurgerTest.php
@@ -78,6 +78,6 @@ final class NonTransactionalConnectionPurgerTest extends AbstractConnectionPurge
 
     private function purge(): void
     {
-        (new NonTransactionalConnectionPurger($this->connection))->purge();
+        new NonTransactionalConnectionPurger($this->connection)->purge();
     }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to make PHP 8.4 the minimum supported version.

## Details
- Make PHP 8.4 the minimum supported version
- Adjust continuous integration workflow
 - Only support PHP 8.4
 - Rename some steps
- Adjust rector rules for 8.4
- Apply new rector rules on all code