### PR TITLE
docs: add kun-init 4-file documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## What this is
+
+`kununu/data-fixtures` is a PHP library that loads data fixtures into any storage
+mechanism for use in tests and development environments. It is installed as a
+Composer package (`kununu/data-fixtures`) and is not intended for production use.
+
+Its design is based on the [Doctrine data-fixtures](https://github.com/doctrine/data-fixtures)
+package.
+
+## Domain
+
+The library provides loaders, executors and purgers that manage fixture classes
+implementing `FixtureInterface`. Fixtures are loaded from a directory, file or
+class name, then executed against a storage backend. Supported storage types:
+Doctrine DBAL connections, PSR-6 cache pools, DynamoDB, Elasticsearch, OpenSearch
+and the Symfony HTTP Client.
+
+## Code layout
+
+- `src/` — library source (PSR-4 `Kununu\DataFixtures\`)
+  - `Adapter/` — storage-specific fixture interfaces
+  - `Executor/` — executors that run fixtures against a backend
+  - `Loader/` — loaders that discover and register fixtures
+  - `Purger/` — purgers that clear a storage backend before loading
+  - `Exception/` — library exceptions
+  - `Tools/` — supporting utilities
+  - `FixtureInterface.php`, `InitializableFixtureInterface.php` — core contracts
+- `tests/` — PHPUnit tests (PSR-4 `Kununu\DataFixtures\Tests\`)
+- `docs/` — fixture-type guides and design notes
+
+## Quality gates
+
+Run via Composer scripts (defined in `composer.json` `scripts`):
+
+- `composer test` — run the test suite
+- `composer phpstan` — static analysis
+- `composer cs` — coding-standards check (PHP CS Fixer, kununu standards)
+- `composer sniffer` — PHP_CodeSniffer
+- `composer rector` — Rector in dry-run mode
+
+CI runs on `.github/workflows/continuous-integration.yml`; quality is also gated
+by SonarCloud.
+
+## Hard constraints
+
+- PHP version is pinned in `composer.json` (`require.php`).
+- Public API changes follow semantic versioning ([SemVer 2.0.0](https://semver.org/)).
+- All code changes require tests.
+- This package must not be used in production mode; consumers own the fixtures
+  they load.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,24 +4,47 @@ Contributions are more than **welcome**.
 
 We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/data-fixtures).
 
-## Pull Requests
+## Development setup
+
+Install the Composer dependencies:
+
+```shell
+composer install
+```
+
+This installs the development tooling, including [kununu/code-tools](https://github.com/kununu/code-tools),
+which exposes the commands used to meet our coding standards.
+
+## Quality gates
+
+Quality gates are defined as Composer scripts in `composer.json` (`scripts`).
+Run them before opening a pull request:
+
+- `composer test` — run the test suite
+- `composer test-coverage` — run the test suite with a coverage report
+- `composer phpstan` — static analysis
+- `composer cs` — coding-standards check (PHP CS Fixer, kununu standards)
+- `composer sniffer` — PHP_CodeSniffer (`composer sniffer-fix` to auto-fix)
+- `composer rector` — Rector in dry-run mode (`composer rector-fix` to apply)
+
+## Pull requests
 
 - **[kununu Coding Standards](https://github.com/kununu/code-tools/blob/main/dist/php-cs-fixer.php.dist)**
-  - The kununu coding standards are an extension of the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md). 
-  - Check out our kununu Coding Standards library, [kununu/code-tools](https://github.com/kununu/code-tools) for more details.
-    - In development mode the package is already a dependency that expose commands that you can use to meet our standards.
+  - The kununu coding standards extend [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
+  - See [kununu/code-tools](https://github.com/kununu/code-tools) for details.
 
 - **Add tests!**
-  - To ensure a high quality code base, your code patch can't be accepted if it does not have tests.
+  - To ensure a high-quality code base, patches without tests cannot be accepted.
 
 - **Document any change in behaviour**
-  - Make sure that the `README.md` and any other relevant documentation files are kept up-to-date.
+  - Keep `README.md` and any other relevant documentation up-to-date.
 
 - **Consider our release cycle**
-  - Since we're using semantic versioning ([SemVer v2.0.0](http://semver.org/)), changes to the API must be done with great consideration, and prevented if at all possible.
+  - We use semantic versioning ([SemVer 2.0.0](https://semver.org/)). Changes to
+    the public API must be made with great consideration and prevented if possible.
 
 - **Create feature branches**
-  - `main` is the stable branch, create a new branch for each feature.
+  - `main` is the stable branch; create a new branch for each feature.
 
 - **One pull request per feature**
   - If you want to do more than one thing, send multiple pull requests.

--- a/README.md
+++ b/README.md
@@ -130,37 +130,10 @@ $loader->addFixture(new YourFixtureClass());
 
 ------------------------------
 
-## Contribute
+## Contributing
 
 If you are interested in contributing read our [contributing guidelines](CONTRIBUTING.md).
-
-------------------------------
-
-## Tests
-
-If not yet, first install composer dependencies:
-
-```shell
-composer install
-```
-
-Run the tests by doing: 
-
-```shell
-vendor/bin/phpunit
-```
-
-To run tests without coverage report:
-```shell
-composer install
-composer test
-```
-
-To run tests with coverage report:
-```shell
-composer install
-composer test-coverage
-```
+This includes how to set up the project locally, run the tests and run the quality gates.
 
 ------------------------------
 


### PR DESCRIPTION
# Description

The objective of this PR is to introduce the standard kun-init 4-file documentation structure with strict ownership and no duplication across files:

- **README.md** — what the library is, installation, usage. Dev workflow removed and pointed at `CONTRIBUTING.md`.
- **AGENTS.md** — short agent-facing overview: what it is, domain, code layout, quality gates (real Composer scripts) and hard constraints.
- **CONTRIBUTING.md** — reconciled the existing file; now owns all development workflow (setup, quality gates) alongside the existing PR guidelines.
- **CLAUDE.md** — contains `@AGENTS.md`.

## Issues

- KUNAI-8

## Details

- Layout detected: **library** (`type: library`, PSR-4 `Kununu\DataFixtures\`, consumed as a Composer package). No k8s-env link added (not a deployed service).
- README `## Tests` section moved into `CONTRIBUTING.md` to remove duplication; CI/SonarCloud badges kept.
- Quality gates reference the real Composer `scripts`; PHP version referenced via `composer.json` (`require.php`) rather than hardcoded.
- CLAUDE.md added normally (not listed in `.gitignore`).